### PR TITLE
223622: Removed demo-payment-web from snd1 environment and set frequency to 1m for scanning repositories

### DIFF
--- a/services/ffc-demo/ffc-demo-web/helm-release.yaml
+++ b/services/ffc-demo/ffc-demo-web/helm-release.yaml
@@ -16,7 +16,7 @@ spec:
         namespace: config-cluster-flux
   install:
     createNamespace: true
-  interval: 5m0s
+  interval: 1m0s
   targetNamespace: ffc-demo
   values:
     aadWorkloadIdentity: true

--- a/services/ffc-demo/ffc-demo-web/helm-repository.yaml
+++ b/services/ffc-demo/ffc-demo-web/helm-repository.yaml
@@ -5,5 +5,5 @@ metadata:
   namespace: config-cluster-flux
 spec:
   type: oci
-  interval: 5m
+  interval: 1m
   url: oci://${ACR_NAME}.azurecr.io/helm

--- a/services/ffc-demo/ffc-demo-web/image-repository.yaml
+++ b/services/ffc-demo/ffc-demo-web/image-repository.yaml
@@ -5,4 +5,4 @@ metadata:
   namespace: config-cluster-flux
 spec:
   image: ${ACR_NAME}.azurecr.io/image/ffc-demo-web
-  interval: 5m0s
+  interval: 1m0s

--- a/services/ffc-demo/snd/01/kustomization.yaml
+++ b/services/ffc-demo/snd/01/kustomization.yaml
@@ -2,11 +2,9 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:             
   - ../../base
-  - ../../ffc-demo-payment-web
   - ../../ffc-demo-web
   - ../../ffc-demo-claim-service  
 
 patches:
-  - path: ../../ffc-demo-payment-web/snd.yaml
   - path: ../../ffc-demo-web/snd.yaml
   - path: ../../ffc-demo-claim-service/snd.yaml  


### PR DESCRIPTION
Removed demo-payment-web application from the flux manifest for snd1 environment
Set the frequency for the repository scanning for the demo-web application to 1 so that changes are synced quicker

AB#223622