### PR TITLE
284393: Create Flux manifests for FFC-FFD alpha testing

### DIFF
--- a/services/environments/snd/base/kustomization.yaml
+++ b/services/environments/snd/base/kustomization.yaml
@@ -3,5 +3,4 @@ kind: Kustomization
 resources:
   - image-update.yaml
   - ../../../ffc-demo/base/patch
-
   - ../../../ffc-ffd/base/patch

--- a/services/environments/snd/base/kustomization.yaml
+++ b/services/environments/snd/base/kustomization.yaml
@@ -4,3 +4,4 @@ resources:
   - image-update.yaml
   - ../../../ffc-demo/base/patch
 
+  - ../../../ffc-ffd/base/patch

--- a/services/ffc-ffd/base/helm-repository.yaml
+++ b/services/ffc-ffd/base/helm-repository.yaml
@@ -1,0 +1,11 @@
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: ffc-ffd-helm-repo
+  namespace: flux-config
+spec:
+  type: oci
+  interval: 5m
+  url: oci://${APPLICATION_ACR_NAME}.azurecr.io/helm
+  provider: azure
+  

--- a/services/ffc-ffd/base/kustomization.yaml
+++ b/services/ffc-ffd/base/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base
+  - helm-repository.yaml

--- a/services/ffc-ffd/base/patch/kustomization.yaml
+++ b/services/ffc-ffd/base/patch/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - kustomize.yaml

--- a/services/ffc-ffd/base/patch/kustomize.yaml
+++ b/services/ffc-ffd/base/patch/kustomize.yaml
@@ -1,0 +1,28 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: ffc-ffd-base
+  namespace: flux-config
+spec:
+  sourceRef:
+    kind: GitRepository
+    name: services-repository
+    namespace: flux-config
+  interval: 5m
+  timeout: 3m
+  prune: true
+  path: ./services/ffc-ffd/${ENVIRONMENT}/${ENVIRONMENT_ID}
+  postBuild:
+    substitute:
+      TEAM_NAMESPACE: "ffc-ffd"
+      TEAM_NAME: "ffc-ffd-team"
+      TEAM_RG: "${SERVICES_INFRA_RG}-ffc-ffd"
+      APPCONFIG_MI_CLIENTID: ${APPCONFIG_MI_CLIENTID}
+      APPCONFIG_NAME: ${APPCONFIG_NAME}
+      SERVICE_CODE: "FFD"
+    substituteFrom:
+      - kind: ConfigMap
+        name: ffc-ffd-mi-credential
+        optional: true
+      - kind: ConfigMap
+        name: adp-platform-vars

--- a/services/ffc-ffd/ffc-ffd-backend-poc/deploy-kustomize.yaml
+++ b/services/ffc-ffd/ffc-ffd-backend-poc/deploy-kustomize.yaml
@@ -1,0 +1,31 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: ffc-ffd-backend-poc-deploy
+  namespace: flux-config
+spec:
+  dependsOn:
+    - name: ffc-ffd-backend-poc-pre-deploy
+      namespace: flux-config
+  sourceRef:
+    kind: GitRepository
+    name: services-repository
+    namespace: flux-config
+  path: ./services/ffc-ffd/ffc-ffd-backend-poc/deploy/${ENVIRONMENT}/${ENVIRONMENT_ID}
+  interval: 5m
+  timeout: 3m
+  prune: true
+  wait: true
+  force: true
+  postBuild:
+    substitute:
+      SERVICE_NAME: "ffc-ffd-backend-poc"
+      TEAM_NAMESPACE: ${TEAM_NAMESPACE}
+      TEAM_NAME: ${TEAM_NAME}
+      APPCONFIG_NAME: ${APPCONFIG_NAME}
+      APPCONFIG_MI_CLIENTID: ${APPCONFIG_MI_CLIENTID}
+    substituteFrom:
+      - kind: ConfigMap
+        name: adp-platform-vars
+      - kind: ConfigMap
+        name: "ffc-ffd-backend-poc-mi-credential"

--- a/services/ffc-ffd/ffc-ffd-backend-poc/deploy/base/helm-release.yaml
+++ b/services/ffc-ffd/ffc-ffd-backend-poc/deploy/base/helm-release.yaml
@@ -1,0 +1,24 @@
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: ffc-ffd-backend-poc
+  namespace: flux-config
+spec:
+  releaseName: ffc-ffd-backend-poc
+  chart:
+    spec:
+      chart: ffc-ffd-backend-poc
+      version: "0.1.0"
+      reconcileStrategy: ChartVersion
+      sourceRef:
+        kind: HelmRepository
+        name: ffc-ffd-helm-repo
+        namespace: flux-config
+  install:
+    createNamespace: true
+  interval: 5m0s
+  targetNamespace: ffc-ffd
+  values:
+    aadWorkloadIdentity: true
+    serviceAccount:
+      name: ffc-ffd

--- a/services/ffc-ffd/ffc-ffd-backend-poc/deploy/base/kustomization.yaml
+++ b/services/ffc-ffd/ffc-ffd-backend-poc/deploy/base/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../../../base/service-account.yaml
+  - helm-release.yaml

--- a/services/ffc-ffd/ffc-ffd-backend-poc/deploy/snd/01/kustomization.yaml
+++ b/services/ffc-ffd/ffc-ffd-backend-poc/deploy/snd/01/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base
+
+patches:
+  - path: patch.yaml

--- a/services/ffc-ffd/ffc-ffd-backend-poc/deploy/snd/01/patch.yaml
+++ b/services/ffc-ffd/ffc-ffd-backend-poc/deploy/snd/01/patch.yaml
@@ -1,0 +1,28 @@
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: ffc-ffd-backend-poc
+  namespace: flux-config
+spec:
+  chart:
+    spec:
+      version: "0.1.0" # {"$imagepolicy": "flux-config:ffc-ffd-backend-poc-snd-01:tag"}
+  values:
+    environment: production
+    name: ffc-ffd-backend-poc
+    namespace: ffc-ffd
+    image: sndadpinfcr1401.azurecr.io/image/ffc-ffd-backend-poc:0.1.0 # {"$imagepolicy": "flux-config:ffc-ffd-backend-poc-snd-01"}
+    serviceAccount:
+      name: ffc-ffd-backend-poc
+    deployment:
+      priorityClassName: default
+    container:
+      imagePullPolicy: Always
+      requestMemory: 5Mi
+      requestCpu: 5m
+      limitMemory: 60Mi
+      limitCpu: 40m
+    containerConfigMap:
+      configServiceName: ${APPCONFIG_NAME}
+      configServiceMIClientId: ${APPCONFIG_MI_CLIENTID}
+      serviceMIClientId: ${clientId}

--- a/services/ffc-ffd/ffc-ffd-backend-poc/deploy/snd/02/kustomization.yaml
+++ b/services/ffc-ffd/ffc-ffd-backend-poc/deploy/snd/02/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base
+
+patches:
+  - path: patch.yaml

--- a/services/ffc-ffd/ffc-ffd-backend-poc/deploy/snd/02/patch.yaml
+++ b/services/ffc-ffd/ffc-ffd-backend-poc/deploy/snd/02/patch.yaml
@@ -1,0 +1,28 @@
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: ffc-ffd-backend-poc
+  namespace: flux-config
+spec:
+  chart:
+    spec:
+      version: "0.1.0" # {"$imagepolicy": "flux-config:ffc-ffd-backend-poc-snd-02:tag"}
+  values:
+    environment: production
+    name: ffc-ffd-backend-poc
+    namespace: ffc-ffd
+    image: sndadpinfcr2401.azurecr.io/image/ffc-ffd-backend-poc:0.1.0 # {"$imagepolicy": "flux-config:ffc-ffd-backend-poc-snd-02"}
+    serviceAccount:
+      name: ffc-ffd-backend-poc
+    deployment:
+      priorityClassName: default
+    container:
+      imagePullPolicy: Always
+      requestMemory: 5Mi
+      requestCpu: 5m
+      limitMemory: 60Mi
+      limitCpu: 40m
+    containerConfigMap:
+      configServiceName: ${APPCONFIG_NAME}
+      configServiceMIClientId: ${APPCONFIG_MI_CLIENTID}
+      serviceMIClientId: ${clientId}

--- a/services/ffc-ffd/ffc-ffd-backend-poc/deploy/snd/03/kustomization.yaml
+++ b/services/ffc-ffd/ffc-ffd-backend-poc/deploy/snd/03/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base
+
+patches:
+  - path: patch.yaml

--- a/services/ffc-ffd/ffc-ffd-backend-poc/deploy/snd/03/patch.yaml
+++ b/services/ffc-ffd/ffc-ffd-backend-poc/deploy/snd/03/patch.yaml
@@ -1,0 +1,28 @@
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: ffc-ffd-backend-poc
+  namespace: flux-config
+spec:
+  chart:
+    spec:
+      version: "0.1.0" # {"$imagepolicy": "flux-config:ffc-ffd-backend-poc-snd-03:tag"}
+  values:
+    environment: production
+    name: ffc-ffd-backend-poc
+    namespace: ffc-ffd
+    image: sndadpinfcr3401.azurecr.io/image/ffc-ffd-backend-poc:0.1.0 # {"$imagepolicy": "flux-config:ffc-ffd-backend-poc-snd-03"}
+    serviceAccount:
+      name: ffc-ffd-backend-poc
+    deployment:
+      priorityClassName: default
+    container:
+      imagePullPolicy: Always
+      requestMemory: 5Mi
+      requestCpu: 5m
+      limitMemory: 60Mi
+      limitCpu: 40m
+    containerConfigMap:
+      configServiceName: ${APPCONFIG_NAME}
+      configServiceMIClientId: ${APPCONFIG_MI_CLIENTID}
+      serviceMIClientId: ${clientId}

--- a/services/ffc-ffd/ffc-ffd-backend-poc/infra-kustomize.yaml
+++ b/services/ffc-ffd/ffc-ffd-backend-poc/infra-kustomize.yaml
@@ -1,0 +1,26 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: ffc-ffd-backend-poc-infra
+  namespace: flux-config
+spec:
+  sourceRef:
+    kind: GitRepository
+    name: services-repository
+    namespace: flux-config
+  path: ./services/ffc-ffd/ffc-ffd-backend-poc/infra/${ENVIRONMENT}/${ENVIRONMENT_ID}
+  interval: 5m
+  timeout: 3m
+  prune: true
+  wait: true
+  force: true
+  postBuild:
+    substitute:
+      SERVICE_NAME: "ffc-ffd-backend-poc"
+      TEAM_RG: ${TEAM_RG}
+      TEAM_NAMESPACE: ${TEAM_NAMESPACE}
+      TEAM_NAME: ${TEAM_NAME}
+      SERVICE_CODE: ${SERVICE_CODE}
+    substituteFrom:
+      - kind: ConfigMap
+        name: adp-platform-vars

--- a/services/ffc-ffd/ffc-ffd-backend-poc/infra/base/aso-helm-release.yaml
+++ b/services/ffc-ffd/ffc-ffd-backend-poc/infra/base/aso-helm-release.yaml
@@ -1,0 +1,22 @@
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: ffc-ffd-backend-poc-infra
+  namespace: flux-config
+spec:
+  releaseName: ffc-ffd-backend-poc-infra
+  chart:
+    spec:
+      chart: ffc-ffd-backend-poc-infra
+      version: "0.1.0"
+      reconcileStrategy: ChartVersion
+      sourceRef:
+        kind: HelmRepository
+        name: ffc-ffd-helm-repo
+        namespace: flux-config
+  install:
+    createNamespace: true
+  interval: 5m0s
+  targetNamespace: ffc-ffd
+  values:
+    namespace: ffc-ffd

--- a/services/ffc-ffd/ffc-ffd-backend-poc/infra/base/image-repository.yaml
+++ b/services/ffc-ffd/ffc-ffd-backend-poc/infra/base/image-repository.yaml
@@ -1,0 +1,9 @@
+apiVersion: image.toolkit.fluxcd.io/v1beta2
+kind: ImageRepository
+metadata:
+  name: ffc-ffd-backend-poc
+  namespace: flux-config
+spec:
+  image: ${APPLICATION_ACR_NAME}.azurecr.io/image/ffc-ffd-backend-poc
+  interval: 5m0s
+  provider: azure

--- a/services/ffc-ffd/ffc-ffd-backend-poc/infra/base/kustomization.yaml
+++ b/services/ffc-ffd/ffc-ffd-backend-poc/infra/base/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - aso-helm-release.yaml
+  - image-repository.yaml

--- a/services/ffc-ffd/ffc-ffd-backend-poc/infra/snd/01/image-policy.yaml
+++ b/services/ffc-ffd/ffc-ffd-backend-poc/infra/snd/01/image-policy.yaml
@@ -1,0 +1,11 @@
+apiVersion: image.toolkit.fluxcd.io/v1beta2
+kind: ImagePolicy
+metadata:
+  name: ffc-ffd-backend-poc-snd-01
+  namespace: flux-config
+spec:
+  imageRepositoryRef:
+    name: ffc-ffd-backend-poc
+  policy:
+    semver:
+      range: '>=0.1.0'

--- a/services/ffc-ffd/ffc-ffd-backend-poc/infra/snd/01/kustomization.yaml
+++ b/services/ffc-ffd/ffc-ffd-backend-poc/infra/snd/01/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base
+  - image-policy.yaml
+patches:
+  - path: patch.yaml

--- a/services/ffc-ffd/ffc-ffd-backend-poc/infra/snd/01/patch.yaml
+++ b/services/ffc-ffd/ffc-ffd-backend-poc/infra/snd/01/patch.yaml
@@ -1,0 +1,37 @@
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: ffc-ffd-backend-poc-infra
+  namespace: flux-config
+spec:
+  chart:
+    spec:
+      version: "0.1.0" # {"$imagepolicy": "flux-config:ffc-ffd-backend-poc-snd-01:tag"}
+  values:
+    namespace: ${TEAM_NAMESPACE}
+    fluxConfigNamespace: ${FLUX_CONFIG_NAMESPACE}
+    subscriptionId: ${SUBSCRIPTION_ID}
+    serviceBusResourceGroupName: ${SERVICES_INFRA_RG}
+    serviceBusNamespaceName: ${SHARED_SERVICEBUS_NAME}
+    postgresResourceGroupName: ${DATABASE_SERVER_RG}
+    postgresServerName: ${SHARED_POSTGRES_SERVER_01}
+    clusterOIDCIssuerUrl: ${CLUSTER_OIDC_ISSUER_URL}
+    teamResourceGroupName: ${TEAM_RG}
+    teamMIPrefix: ${TEAM_MI_PREFIX}
+    serviceName: ${SERVICE_NAME}
+    keyVaultResourceGroupName: ${SERVICES_INFRA_RG}
+    keyVaultName: sndadpinfvt1401
+    userAssignedIdentity:
+      federatedCreds:
+        - namespace: ${TEAM_NAMESPACE}
+          serviceAccountName: ${SERVICE_NAME}
+        - namespace: 'app-config-service'
+          serviceAccountName: 'az-appconfig-k8s-provider'
+    commonTags:
+      environment: ${ENVIRONMENT}
+      serviceCode: ${SERVICE_CODE}
+      serviceName: ${SERVICE_NAME}
+      serviceType: "Dedicated"
+      kubernetes_cluster: ${CLUSTER_NAME}
+      kubernetes_namespace: ${TEAM_NAMESPACE}
+      kubernetes_label_serviceCode: ${SERVICE_CODE}

--- a/services/ffc-ffd/ffc-ffd-backend-poc/infra/snd/02/image-policy.yaml
+++ b/services/ffc-ffd/ffc-ffd-backend-poc/infra/snd/02/image-policy.yaml
@@ -1,0 +1,11 @@
+apiVersion: image.toolkit.fluxcd.io/v1beta2
+kind: ImagePolicy
+metadata:
+  name: ffc-ffd-backend-poc-snd-02
+  namespace: flux-config
+spec:
+  imageRepositoryRef:
+    name: ffc-ffd-backend-poc
+  policy:
+    semver:
+      range: '>=0.1.0'

--- a/services/ffc-ffd/ffc-ffd-backend-poc/infra/snd/02/kustomization.yaml
+++ b/services/ffc-ffd/ffc-ffd-backend-poc/infra/snd/02/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base
+  - image-policy.yaml
+patches:
+  - path: patch.yaml

--- a/services/ffc-ffd/ffc-ffd-backend-poc/infra/snd/02/patch.yaml
+++ b/services/ffc-ffd/ffc-ffd-backend-poc/infra/snd/02/patch.yaml
@@ -1,0 +1,37 @@
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: ffc-ffd-backend-poc-infra
+  namespace: flux-config
+spec:
+  chart:
+    spec:
+      version: "0.1.0" # {"$imagepolicy": "flux-config:ffc-ffd-backend-poc-snd-02:tag"}
+  values:
+    namespace: ${TEAM_NAMESPACE}
+    fluxConfigNamespace: ${FLUX_CONFIG_NAMESPACE}
+    subscriptionId: ${SUBSCRIPTION_ID}
+    serviceBusResourceGroupName: ${SERVICES_INFRA_RG}
+    serviceBusNamespaceName: ${SHARED_SERVICEBUS_NAME}
+    postgresResourceGroupName: ${DATABASE_SERVER_RG}
+    postgresServerName: ${SHARED_POSTGRES_SERVER_01}
+    clusterOIDCIssuerUrl: ${CLUSTER_OIDC_ISSUER_URL}
+    teamResourceGroupName: ${TEAM_RG}
+    teamMIPrefix: ${TEAM_MI_PREFIX}
+    serviceName: ${SERVICE_NAME}
+    keyVaultResourceGroupName: ${SERVICES_INFRA_RG}
+    keyVaultName: sndadpinfvt2401
+    userAssignedIdentity:
+      federatedCreds:
+        - namespace: ${TEAM_NAMESPACE}
+          serviceAccountName: ${SERVICE_NAME}
+        - namespace: 'app-config-service'
+          serviceAccountName: 'az-appconfig-k8s-provider'
+    commonTags:
+      environment: ${ENVIRONMENT}
+      serviceCode: ${SERVICE_CODE}
+      serviceName: ${SERVICE_NAME}
+      serviceType: "Dedicated"
+      kubernetes_cluster: ${CLUSTER_NAME}
+      kubernetes_namespace: ${TEAM_NAMESPACE}
+      kubernetes_label_serviceCode: ${SERVICE_CODE}

--- a/services/ffc-ffd/ffc-ffd-backend-poc/infra/snd/03/image-policy.yaml
+++ b/services/ffc-ffd/ffc-ffd-backend-poc/infra/snd/03/image-policy.yaml
@@ -1,0 +1,11 @@
+apiVersion: image.toolkit.fluxcd.io/v1beta2
+kind: ImagePolicy
+metadata:
+  name: ffc-ffd-backend-poc-snd-03
+  namespace: flux-config
+spec:
+  imageRepositoryRef:
+    name: ffc-ffd-backend-poc
+  policy:
+    semver:
+      range: '>=0.1.0'

--- a/services/ffc-ffd/ffc-ffd-backend-poc/infra/snd/03/kustomization.yaml
+++ b/services/ffc-ffd/ffc-ffd-backend-poc/infra/snd/03/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base
+  - image-policy.yaml
+patches:
+  - path: patch.yaml

--- a/services/ffc-ffd/ffc-ffd-backend-poc/infra/snd/03/patch.yaml
+++ b/services/ffc-ffd/ffc-ffd-backend-poc/infra/snd/03/patch.yaml
@@ -1,0 +1,37 @@
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: ffc-ffd-backend-poc-infra
+  namespace: flux-config
+spec:
+  chart:
+    spec:
+      version: "0.1.0" # {"$imagepolicy": "flux-config:ffc-ffd-backend-poc-snd-03:tag"}
+  values:
+    namespace: ${TEAM_NAMESPACE}
+    fluxConfigNamespace: ${FLUX_CONFIG_NAMESPACE}
+    subscriptionId: ${SUBSCRIPTION_ID}
+    serviceBusResourceGroupName: ${SERVICES_INFRA_RG}
+    serviceBusNamespaceName: ${SHARED_SERVICEBUS_NAME}
+    postgresResourceGroupName: ${DATABASE_SERVER_RG}
+    postgresServerName: ${SHARED_POSTGRES_SERVER_01}
+    clusterOIDCIssuerUrl: ${CLUSTER_OIDC_ISSUER_URL}
+    teamResourceGroupName: ${TEAM_RG}
+    teamMIPrefix: ${TEAM_MI_PREFIX}
+    serviceName: ${SERVICE_NAME}
+    keyVaultResourceGroupName: ${SERVICES_INFRA_RG}
+    keyVaultName: sndadpinfvt3401
+    userAssignedIdentity:
+      federatedCreds:
+        - namespace: ${TEAM_NAMESPACE}
+          serviceAccountName: ${SERVICE_NAME}
+        - namespace: 'app-config-service'
+          serviceAccountName: 'az-appconfig-k8s-provider'
+    commonTags:
+      environment: ${ENVIRONMENT}
+      serviceCode: ${SERVICE_CODE}
+      serviceName: ${SERVICE_NAME}
+      serviceType: "Dedicated"
+      kubernetes_cluster: ${CLUSTER_NAME}
+      kubernetes_namespace: ${TEAM_NAMESPACE}
+      kubernetes_label_serviceCode: ${SERVICE_CODE}

--- a/services/ffc-ffd/ffc-ffd-backend-poc/kustomization.yaml
+++ b/services/ffc-ffd/ffc-ffd-backend-poc/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - infra-kustomize.yaml
+  - deploy-kustomize.yaml
+  - pre-deploy-kustomize.yaml

--- a/services/ffc-ffd/ffc-ffd-backend-poc/pre-deploy-kustomize.yaml
+++ b/services/ffc-ffd/ffc-ffd-backend-poc/pre-deploy-kustomize.yaml
@@ -1,0 +1,30 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: ffc-ffd-backend-poc-pre-deploy
+  namespace: flux-config
+spec:
+  dependsOn:
+    - name: ffc-ffd-backend-poc-infra
+      namespace: flux-config
+  sourceRef:
+    kind: GitRepository
+    name: services-repository
+    namespace: flux-config
+  path: ./services/ffc-ffd/ffc-ffd-backend-poc/pre-deploy/${ENVIRONMENT}/${ENVIRONMENT_ID}
+  interval: 5m
+  timeout: 3m
+  prune: true
+  wait: true
+  force: true
+  postBuild:
+    substitute:
+      SHARED_POSTGRES_SERVER_01: "${SHARED_POSTGRES_SERVER_01}"
+      SERVICE_NAME: "ffc-ffd-backend-poc"
+      TEAM_NAMESPACE: ${TEAM_NAMESPACE}
+      TEAM_NAME: ${TEAM_NAME}
+    substituteFrom:
+      - kind: ConfigMap
+        name: adp-platform-vars
+      - kind: ConfigMap
+        name: "ffc-ffd-backend-poc-mi-credential"

--- a/services/ffc-ffd/ffc-ffd-backend-poc/pre-deploy/base/image-repository-dbmigration.yaml
+++ b/services/ffc-ffd/ffc-ffd-backend-poc/pre-deploy/base/image-repository-dbmigration.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: image.toolkit.fluxcd.io/v1beta2
+kind: ImageRepository
+metadata:
+  name: ffc-ffd-backend-poc-dbmigration
+  namespace: flux-config
+spec:
+  image: ${APPLICATION_ACR_NAME}.azurecr.io/image/ffc-ffd-backend-poc-dbmigration
+  interval: 5m0s
+  provider: azure

--- a/services/ffc-ffd/ffc-ffd-backend-poc/pre-deploy/base/kustomization.yaml
+++ b/services/ffc-ffd/ffc-ffd-backend-poc/pre-deploy/base/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../../../base/service-account.yaml
+  - image-repository-dbmigration.yaml
+  - migration.job.yaml

--- a/services/ffc-ffd/ffc-ffd-backend-poc/pre-deploy/base/migration.job.yaml
+++ b/services/ffc-ffd/ffc-ffd-backend-poc/pre-deploy/base/migration.job.yaml
@@ -1,0 +1,18 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: ffc-ffd-backend-poc-dbmigration
+  namespace: ffc-ffd
+  labels:
+    azure.workload.identity/use: "true"
+spec:
+  template:
+    metadata:
+      labels:
+        azure.workload.identity/use: "true"
+    spec:
+      serviceAccountName: ${SERVICE_NAME}
+      restartPolicy: Never
+      containers:
+      - name: ffc-ffd-backend-poc-dbmigration
+        imagePullPolicy: Always

--- a/services/ffc-ffd/ffc-ffd-backend-poc/pre-deploy/snd/01/image-policy.yaml
+++ b/services/ffc-ffd/ffc-ffd-backend-poc/pre-deploy/snd/01/image-policy.yaml
@@ -1,0 +1,11 @@
+apiVersion: image.toolkit.fluxcd.io/v1beta2
+kind: ImagePolicy
+metadata:
+  name: ffc-ffd-backend-poc-dbmigration-snd-01
+  namespace: flux-config
+spec:
+  imageRepositoryRef:
+    name: ffc-ffd-backend-poc-dbmigration
+  policy:
+    semver:
+      range: '>=0.1.0'

--- a/services/ffc-ffd/ffc-ffd-backend-poc/pre-deploy/snd/01/kustomization.yaml
+++ b/services/ffc-ffd/ffc-ffd-backend-poc/pre-deploy/snd/01/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base
+  - image-policy.yaml
+patches:
+  - path: patch.yaml

--- a/services/ffc-ffd/ffc-ffd-backend-poc/pre-deploy/snd/01/patch.yaml
+++ b/services/ffc-ffd/ffc-ffd-backend-poc/pre-deploy/snd/01/patch.yaml
@@ -1,0 +1,22 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: ffc-ffd-backend-poc-dbmigration
+  namespace: ffc-ffd
+spec:
+  template:
+    spec:
+      containers:
+      - name: ffc-ffd-backend-poc-dbmigration
+        image: sndadpinfcr1401.azurecr.io/image/ffc-ffd-backend-poc-dbmigration:0.1.0 # {"$imagepolicy": "flux-config:ffc-ffd-backend-poc-dbmigration-snd-01"}
+        env:
+        - name: POSTGRES_HOST
+          value: "${SHARED_POSTGRES_SERVER_01}.postgres.database.azure.com"
+        - name: SCHEMA_NAME
+          value: "public"
+        - name: POSTGRES_DB
+          value: "${POSTGRES_DB}"
+        - name: POSTGRES_PORT
+          value: "5432"
+        - name: SCHEMA_USERNAME
+          value: ${TEAM_MI_PREFIX}-${SERVICE_NAME}

--- a/services/ffc-ffd/ffc-ffd-backend-poc/pre-deploy/snd/02/image-policy.yaml
+++ b/services/ffc-ffd/ffc-ffd-backend-poc/pre-deploy/snd/02/image-policy.yaml
@@ -1,0 +1,11 @@
+apiVersion: image.toolkit.fluxcd.io/v1beta2
+kind: ImagePolicy
+metadata:
+  name: ffc-ffd-backend-poc-dbmigration-snd-01
+  namespace: flux-config
+spec:
+  imageRepositoryRef:
+    name: ffc-ffd-backend-poc-dbmigration
+  policy:
+    semver:
+      range: '>=0.1.0'

--- a/services/ffc-ffd/ffc-ffd-backend-poc/pre-deploy/snd/02/kustomization.yaml
+++ b/services/ffc-ffd/ffc-ffd-backend-poc/pre-deploy/snd/02/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base
+  - image-policy.yaml
+patches:
+  - path: patch.yaml

--- a/services/ffc-ffd/ffc-ffd-backend-poc/pre-deploy/snd/02/patch.yaml
+++ b/services/ffc-ffd/ffc-ffd-backend-poc/pre-deploy/snd/02/patch.yaml
@@ -1,0 +1,22 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: ffc-ffd-backend-poc-dbmigration
+  namespace: ffc-ffd
+spec:
+  template:
+    spec:
+      containers:
+      - name: ffc-ffd-backend-poc-dbmigration
+        image: sndadpinfcr2401.azurecr.io/image/ffc-ffd-backend-poc-dbmigration:0.1.0 # {"$imagepolicy": "flux-config:ffc-ffd-backend-poc-dbmigration-snd-02"}
+        env:
+        - name: POSTGRES_HOST
+          value: "${SHARED_POSTGRES_SERVER_01}.postgres.database.azure.com"
+        - name: SCHEMA_NAME
+          value: "public"
+        - name: POSTGRES_DB
+          value: "${POSTGRES_DB}"
+        - name: POSTGRES_PORT
+          value: "5432"
+        - name: SCHEMA_USERNAME
+          value: ${TEAM_MI_PREFIX}-${SERVICE_NAME}

--- a/services/ffc-ffd/ffc-ffd-backend-poc/pre-deploy/snd/03/image-policy.yaml
+++ b/services/ffc-ffd/ffc-ffd-backend-poc/pre-deploy/snd/03/image-policy.yaml
@@ -1,0 +1,11 @@
+apiVersion: image.toolkit.fluxcd.io/v1beta2
+kind: ImagePolicy
+metadata:
+  name: ffc-ffd-backend-poc-dbmigration-snd-01
+  namespace: flux-config
+spec:
+  imageRepositoryRef:
+    name: ffc-ffd-backend-poc-dbmigration
+  policy:
+    semver:
+      range: '>=0.1.0'

--- a/services/ffc-ffd/ffc-ffd-backend-poc/pre-deploy/snd/03/kustomization.yaml
+++ b/services/ffc-ffd/ffc-ffd-backend-poc/pre-deploy/snd/03/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base
+  - image-policy.yaml
+patches:
+  - path: patch.yaml

--- a/services/ffc-ffd/ffc-ffd-backend-poc/pre-deploy/snd/03/patch.yaml
+++ b/services/ffc-ffd/ffc-ffd-backend-poc/pre-deploy/snd/03/patch.yaml
@@ -1,0 +1,22 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: ffc-ffd-backend-poc-dbmigration
+  namespace: ffc-ffd
+spec:
+  template:
+    spec:
+      containers:
+      - name: ffc-ffd-backend-poc-dbmigration
+        image: sndadpinfcr3401.azurecr.io/image/ffc-ffd-backend-poc-dbmigration:0.1.0 # {"$imagepolicy": "flux-config:ffc-ffd-backend-poc-dbmigration-snd-03"}
+        env:
+        - name: POSTGRES_HOST
+          value: "${SHARED_POSTGRES_SERVER_01}.postgres.database.azure.com"
+        - name: SCHEMA_NAME
+          value: "public"
+        - name: POSTGRES_DB
+          value: "${POSTGRES_DB}"
+        - name: POSTGRES_PORT
+          value: "5432"
+        - name: SCHEMA_USERNAME
+          value: ${TEAM_MI_PREFIX}-${SERVICE_NAME}

--- a/services/ffc-ffd/ffc-ffd-frontend-poc/deploy-kustomize.yaml
+++ b/services/ffc-ffd/ffc-ffd-frontend-poc/deploy-kustomize.yaml
@@ -1,0 +1,31 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: ffc-ffd-frontend-poc-deploy
+  namespace: flux-config
+spec:
+  dependsOn:
+    - name: ffc-ffd-frontend-poc-infra
+      namespace: flux-config
+  sourceRef:
+    kind: GitRepository
+    name: services-repository
+    namespace: flux-config
+  path: ./services/ffc-ffd/ffc-ffd-frontend-poc/deploy/${ENVIRONMENT}/${ENVIRONMENT_ID}
+  interval: 5m
+  timeout: 3m
+  prune: true
+  wait: true
+  force: true
+  postBuild:
+    substitute:
+      SERVICE_NAME: "ffc-ffd-frontend-poc"
+      TEAM_NAMESPACE: ${TEAM_NAMESPACE}
+      TEAM_NAME: ${TEAM_NAME}
+      APPCONFIG_NAME: ${APPCONFIG_NAME}
+      APPCONFIG_MI_CLIENTID: ${APPCONFIG_MI_CLIENTID}
+    substituteFrom:
+      - kind: ConfigMap
+        name: adp-platform-vars
+      - kind: ConfigMap
+        name: "ffc-ffd-frontend-poc-mi-credential"

--- a/services/ffc-ffd/ffc-ffd-frontend-poc/deploy/base/helm-release.yaml
+++ b/services/ffc-ffd/ffc-ffd-frontend-poc/deploy/base/helm-release.yaml
@@ -1,0 +1,24 @@
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: ffc-ffd-frontend-poc
+  namespace: flux-config
+spec:
+  releaseName: ffc-ffd-frontend-poc
+  chart:
+    spec:
+      chart: ffc-ffd-frontend-poc
+      version: "0.1.0"
+      reconcileStrategy: ChartVersion
+      sourceRef:
+        kind: HelmRepository
+        name: ffc-ffd-helm-repo
+        namespace: flux-config
+  install:
+    createNamespace: true
+  interval: 5m0s
+  targetNamespace: ffc-ffd
+  values:
+    aadWorkloadIdentity: true
+    serviceAccount:
+      name: ffc-ffd

--- a/services/ffc-ffd/ffc-ffd-frontend-poc/deploy/base/kustomization.yaml
+++ b/services/ffc-ffd/ffc-ffd-frontend-poc/deploy/base/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../../../base/service-account.yaml
+  - helm-release.yaml

--- a/services/ffc-ffd/ffc-ffd-frontend-poc/deploy/snd/01/kustomization.yaml
+++ b/services/ffc-ffd/ffc-ffd-frontend-poc/deploy/snd/01/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base
+
+patches:
+  - path: patch.yaml

--- a/services/ffc-ffd/ffc-ffd-frontend-poc/deploy/snd/01/patch.yaml
+++ b/services/ffc-ffd/ffc-ffd-frontend-poc/deploy/snd/01/patch.yaml
@@ -1,0 +1,34 @@
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: ffc-ffd-frontend-poc
+  namespace: flux-config
+spec:
+  chart:
+    spec:
+      version: "0.1.0" # {"$imagepolicy": "flux-config:ffc-ffd-frontend-poc-snd-01:tag"}
+  values:
+    environment: production
+    name: ffc-ffd-frontend-poc
+    namespace: ffc-ffd
+    image: sndadpinfcr1401.azurecr.io/image/ffc-ffd-frontend-poc:0.1.0 # {"$imagepolicy": "flux-config:ffc-ffd-frontend-poc-snd-01"}
+    serviceAccount:
+      name: ffc-ffd-frontend-poc
+    labels:
+      component: web
+    container:
+      imagePullPolicy: Always
+      requestMemory: 50Mi
+      requestCpu: 50m
+      limitMemory: 200Mi
+      limitCpu: 400m
+    ingress:
+      class: nginx
+      endpoint: ffc-ffd-frontend-poc
+      server: snd1.adp.defra.gov.uk
+    deployment:
+      priorityClassName: default
+    containerConfigMap:
+      configServiceName: ${APPCONFIG_NAME}
+      configServiceMIClientId: ${APPCONFIG_MI_CLIENTID}
+      serviceMIClientId: ${clientId}

--- a/services/ffc-ffd/ffc-ffd-frontend-poc/deploy/snd/02/kustomization.yaml
+++ b/services/ffc-ffd/ffc-ffd-frontend-poc/deploy/snd/02/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base
+
+patches:
+  - path: patch.yaml

--- a/services/ffc-ffd/ffc-ffd-frontend-poc/deploy/snd/02/patch.yaml
+++ b/services/ffc-ffd/ffc-ffd-frontend-poc/deploy/snd/02/patch.yaml
@@ -1,0 +1,34 @@
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: ffc-ffd-frontend-poc
+  namespace: flux-config
+spec:
+  chart:
+    spec:
+      version: "0.1.0" # {"$imagepolicy": "flux-config:ffc-ffd-frontend-poc-snd-02:tag"}
+  values:
+    environment: production
+    name: ffc-ffd-frontend-poc
+    namespace: ffc-ffd
+    image: sndadpinfcr2401.azurecr.io/image/ffc-ffd-frontend-poc:0.1.0 # {"$imagepolicy": "flux-config:ffc-ffd-frontend-poc-snd-02"}
+    serviceAccount:
+      name: ffc-ffd-frontend-poc
+    labels:
+      component: web
+    container:
+      imagePullPolicy: Always
+      requestMemory: 50Mi
+      requestCpu: 50m
+      limitMemory: 200Mi
+      limitCpu: 400m
+    ingress:
+      class: nginx
+      endpoint: ffc-ffd-frontend-poc
+      server: snd2.adp.defra.gov.uk
+    deployment:
+      priorityClassName: default
+    containerConfigMap:
+      configServiceName: ${APPCONFIG_NAME}
+      configServiceMIClientId: ${APPCONFIG_MI_CLIENTID}
+      serviceMIClientId: ${clientId}

--- a/services/ffc-ffd/ffc-ffd-frontend-poc/deploy/snd/03/kustomization.yaml
+++ b/services/ffc-ffd/ffc-ffd-frontend-poc/deploy/snd/03/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base
+
+patches:
+  - path: patch.yaml

--- a/services/ffc-ffd/ffc-ffd-frontend-poc/deploy/snd/03/patch.yaml
+++ b/services/ffc-ffd/ffc-ffd-frontend-poc/deploy/snd/03/patch.yaml
@@ -1,0 +1,34 @@
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: ffc-ffd-frontend-poc
+  namespace: flux-config
+spec:
+  chart:
+    spec:
+      version: "0.1.0" # {"$imagepolicy": "flux-config:ffc-ffd-frontend-poc-snd-03:tag"}
+  values:
+    environment: production
+    name: ffc-ffd-frontend-poc
+    namespace: ffc-ffd
+    image: sndadpinfcr3401.azurecr.io/image/ffc-ffd-frontend-poc:0.1.0 # {"$imagepolicy": "flux-config:ffc-ffd-frontend-poc-snd-03"}
+    serviceAccount:
+      name: ffc-ffd-frontend-poc
+    labels:
+      component: web
+    container:
+      imagePullPolicy: Always
+      requestMemory: 50Mi
+      requestCpu: 50m
+      limitMemory: 200Mi
+      limitCpu: 400m
+    ingress:
+      class: nginx
+      endpoint: ffc-ffd-frontend-poc
+      server: snd3.adp.defra.gov.uk
+    deployment:
+      priorityClassName: default
+    containerConfigMap:
+      configServiceName: ${APPCONFIG_NAME}
+      configServiceMIClientId: ${APPCONFIG_MI_CLIENTID}
+      serviceMIClientId: ${clientId}

--- a/services/ffc-ffd/ffc-ffd-frontend-poc/infra-kustomize.yaml
+++ b/services/ffc-ffd/ffc-ffd-frontend-poc/infra-kustomize.yaml
@@ -1,0 +1,26 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: ffc-ffd-frontend-poc-infra
+  namespace: flux-config
+spec:
+  sourceRef:
+    kind: GitRepository
+    name: services-repository
+    namespace: flux-config
+  path: ./services/ffc-ffd/ffc-ffd-frontend-poc/infra/${ENVIRONMENT}/${ENVIRONMENT_ID}
+  interval: 5m
+  timeout: 3m
+  prune: true
+  wait: true
+  force: true
+  postBuild:
+    substitute:
+      SERVICE_NAME: "ffc-ffd-frontend-poc"
+      TEAM_RG: ${TEAM_RG}
+      TEAM_NAMESPACE: ${TEAM_NAMESPACE}
+      TEAM_NAME: ${TEAM_NAME}
+      SERVICE_CODE: ${SERVICE_CODE}
+    substituteFrom:
+      - kind: ConfigMap
+        name: adp-platform-vars

--- a/services/ffc-ffd/ffc-ffd-frontend-poc/infra/base/aso-helm-release.yaml
+++ b/services/ffc-ffd/ffc-ffd-frontend-poc/infra/base/aso-helm-release.yaml
@@ -1,0 +1,22 @@
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: ffc-ffd-frontend-poc-infra
+  namespace: flux-config
+spec:
+  releaseName: ffc-ffd-frontend-poc-infra
+  chart:
+    spec:
+      chart: ffc-ffd-frontend-poc-infra
+      version: "0.1.0"
+      reconcileStrategy: ChartVersion
+      sourceRef:
+        kind: HelmRepository
+        name: ffc-ffd-helm-repo
+        namespace: flux-config
+  install:
+    createNamespace: true
+  interval: 5m0s
+  targetNamespace: ffc-ffd
+  values:
+    namespace: ffc-ffd

--- a/services/ffc-ffd/ffc-ffd-frontend-poc/infra/base/image-repository.yaml
+++ b/services/ffc-ffd/ffc-ffd-frontend-poc/infra/base/image-repository.yaml
@@ -1,0 +1,9 @@
+apiVersion: image.toolkit.fluxcd.io/v1beta2
+kind: ImageRepository
+metadata:
+  name: ffc-ffd-frontend-poc
+  namespace: flux-config
+spec:
+  image: ${APPLICATION_ACR_NAME}.azurecr.io/image/ffc-ffd-frontend-poc
+  interval: 5m0s
+  provider: azure

--- a/services/ffc-ffd/ffc-ffd-frontend-poc/infra/base/kustomization.yaml
+++ b/services/ffc-ffd/ffc-ffd-frontend-poc/infra/base/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - aso-helm-release.yaml
+  - image-repository.yaml

--- a/services/ffc-ffd/ffc-ffd-frontend-poc/infra/snd/01/image-policy.yaml
+++ b/services/ffc-ffd/ffc-ffd-frontend-poc/infra/snd/01/image-policy.yaml
@@ -1,0 +1,11 @@
+apiVersion: image.toolkit.fluxcd.io/v1beta2
+kind: ImagePolicy
+metadata:
+  name: ffc-ffd-frontend-poc-snd-01
+  namespace: flux-config
+spec:
+  imageRepositoryRef:
+    name: ffc-ffd-frontend-poc
+  policy:
+    semver:
+      range: '>=0.1.0'

--- a/services/ffc-ffd/ffc-ffd-frontend-poc/infra/snd/01/kustomization.yaml
+++ b/services/ffc-ffd/ffc-ffd-frontend-poc/infra/snd/01/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base
+  - image-policy.yaml
+patches:
+  - path: patch.yaml

--- a/services/ffc-ffd/ffc-ffd-frontend-poc/infra/snd/01/patch.yaml
+++ b/services/ffc-ffd/ffc-ffd-frontend-poc/infra/snd/01/patch.yaml
@@ -1,0 +1,36 @@
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: ffc-ffd-frontend-poc-infra
+  namespace: flux-config
+spec:
+  chart:
+    spec:
+      chart: ffc-ffd-frontend-poc-infra
+      version: "0.1.0" # {"$imagepolicy": "flux-config:ffc-ffd-frontend-poc-snd-01:tag"}
+  values:
+    namespace: ${TEAM_NAMESPACE}
+    fluxConfigNamespace: ${FLUX_CONFIG_NAMESPACE}
+    subscriptionId: ${SUBSCRIPTION_ID}
+    serviceBusResourceGroupName: ${SERVICES_INFRA_RG}
+    serviceBusNamespaceName: ${SHARED_SERVICEBUS_NAME}
+    clusterOIDCIssuerUrl: ${CLUSTER_OIDC_ISSUER_URL}
+    teamResourceGroupName: ${TEAM_RG}
+    teamMIPrefix: ${TEAM_MI_PREFIX}
+    serviceName: ${SERVICE_NAME}
+    keyVaultResourceGroupName: ${SERVICES_INFRA_RG}
+    keyVaultName: sndadpinfvt1401
+    userAssignedIdentity:
+      federatedCreds:
+        - namespace: ${TEAM_NAMESPACE}
+          serviceAccountName: ${SERVICE_NAME}
+        - namespace: 'app-config-service'
+          serviceAccountName: 'az-appconfig-k8s-provider'
+    commonTags:
+      environment: ${ENVIRONMENT}
+      serviceCode: ${SERVICE_CODE}
+      serviceName: ${SERVICE_NAME}
+      serviceType: "Dedicated"
+      kubernetes_cluster: ${CLUSTER_NAME}
+      kubernetes_namespace: ${TEAM_NAMESPACE}
+      kubernetes_label_serviceCode: ${SERVICE_CODE}

--- a/services/ffc-ffd/ffc-ffd-frontend-poc/infra/snd/02/image-policy.yaml
+++ b/services/ffc-ffd/ffc-ffd-frontend-poc/infra/snd/02/image-policy.yaml
@@ -1,0 +1,11 @@
+apiVersion: image.toolkit.fluxcd.io/v1beta2
+kind: ImagePolicy
+metadata:
+  name: ffc-ffd-frontend-poc-snd-02
+  namespace: flux-config
+spec:
+  imageRepositoryRef:
+    name: ffc-ffd-frontend-poc
+  policy:
+    semver:
+      range: '>=0.1.0'

--- a/services/ffc-ffd/ffc-ffd-frontend-poc/infra/snd/02/kustomization.yaml
+++ b/services/ffc-ffd/ffc-ffd-frontend-poc/infra/snd/02/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base
+  - image-policy.yaml
+patches:
+  - path: patch.yaml

--- a/services/ffc-ffd/ffc-ffd-frontend-poc/infra/snd/02/patch.yaml
+++ b/services/ffc-ffd/ffc-ffd-frontend-poc/infra/snd/02/patch.yaml
@@ -1,0 +1,36 @@
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: ffc-ffd-frontend-poc-infra
+  namespace: flux-config
+spec:
+  chart:
+    spec:
+      chart: ffc-ffd-frontend-poc-infra
+      version: "0.1.0" # {"$imagepolicy": "flux-config:ffc-ffd-frontend-poc-snd-02:tag"}
+  values:
+    namespace: ${TEAM_NAMESPACE}
+    fluxConfigNamespace: ${FLUX_CONFIG_NAMESPACE}
+    subscriptionId: ${SUBSCRIPTION_ID}
+    serviceBusResourceGroupName: ${SERVICES_INFRA_RG}
+    serviceBusNamespaceName: ${SHARED_SERVICEBUS_NAME}
+    clusterOIDCIssuerUrl: ${CLUSTER_OIDC_ISSUER_URL}
+    teamResourceGroupName: ${TEAM_RG}
+    teamMIPrefix: ${TEAM_MI_PREFIX}
+    serviceName: ${SERVICE_NAME}
+    keyVaultResourceGroupName: ${SERVICES_INFRA_RG}
+    keyVaultName: sndadpinfvt2401
+    userAssignedIdentity:
+      federatedCreds:
+        - namespace: ${TEAM_NAMESPACE}
+          serviceAccountName: ${SERVICE_NAME}
+        - namespace: 'app-config-service'
+          serviceAccountName: 'az-appconfig-k8s-provider'
+    commonTags:
+      environment: ${ENVIRONMENT}
+      serviceCode: ${SERVICE_CODE}
+      serviceName: ${SERVICE_NAME}
+      serviceType: "Dedicated"
+      kubernetes_cluster: ${CLUSTER_NAME}
+      kubernetes_namespace: ${TEAM_NAMESPACE}
+      kubernetes_label_serviceCode: ${SERVICE_CODE}

--- a/services/ffc-ffd/ffc-ffd-frontend-poc/infra/snd/03/image-policy.yaml
+++ b/services/ffc-ffd/ffc-ffd-frontend-poc/infra/snd/03/image-policy.yaml
@@ -1,0 +1,11 @@
+apiVersion: image.toolkit.fluxcd.io/v1beta2
+kind: ImagePolicy
+metadata:
+  name: ffc-ffd-frontend-poc-snd-03
+  namespace: flux-config
+spec:
+  imageRepositoryRef:
+    name: ffc-ffd-frontend-poc
+  policy:
+    semver:
+      range: '>=0.1.0'

--- a/services/ffc-ffd/ffc-ffd-frontend-poc/infra/snd/03/kustomization.yaml
+++ b/services/ffc-ffd/ffc-ffd-frontend-poc/infra/snd/03/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base
+  - image-policy.yaml
+patches:
+  - path: patch.yaml

--- a/services/ffc-ffd/ffc-ffd-frontend-poc/infra/snd/03/patch.yaml
+++ b/services/ffc-ffd/ffc-ffd-frontend-poc/infra/snd/03/patch.yaml
@@ -1,0 +1,36 @@
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: ffc-ffd-frontend-poc-infra
+  namespace: flux-config
+spec:
+  chart:
+    spec:
+      chart: ffc-ffd-frontend-poc-infra
+      version: "0.1.0" # {"$imagepolicy": "flux-config:ffc-ffd-frontend-poc-snd-03:tag"}
+  values:
+    namespace: ${TEAM_NAMESPACE}
+    fluxConfigNamespace: ${FLUX_CONFIG_NAMESPACE}
+    subscriptionId: ${SUBSCRIPTION_ID}
+    serviceBusResourceGroupName: ${SERVICES_INFRA_RG}
+    serviceBusNamespaceName: ${SHARED_SERVICEBUS_NAME}
+    clusterOIDCIssuerUrl: ${CLUSTER_OIDC_ISSUER_URL}
+    teamResourceGroupName: ${TEAM_RG}
+    teamMIPrefix: ${TEAM_MI_PREFIX}
+    serviceName: ${SERVICE_NAME}
+    keyVaultResourceGroupName: ${SERVICES_INFRA_RG}
+    keyVaultName: sndadpinfvt3401
+    userAssignedIdentity:
+      federatedCreds:
+        - namespace: ${TEAM_NAMESPACE}
+          serviceAccountName: ${SERVICE_NAME}
+        - namespace: 'app-config-service'
+          serviceAccountName: 'az-appconfig-k8s-provider'
+    commonTags:
+      environment: ${ENVIRONMENT}
+      serviceCode: ${SERVICE_CODE}
+      serviceName: ${SERVICE_NAME}
+      serviceType: "Dedicated"
+      kubernetes_cluster: ${CLUSTER_NAME}
+      kubernetes_namespace: ${TEAM_NAMESPACE}
+      kubernetes_label_serviceCode: ${SERVICE_CODE}

--- a/services/ffc-ffd/ffc-ffd-frontend-poc/kustomization.yaml
+++ b/services/ffc-ffd/ffc-ffd-frontend-poc/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - infra-kustomize.yaml
+  - deploy-kustomize.yaml

--- a/services/ffc-ffd/snd/01/kustomization.yaml
+++ b/services/ffc-ffd/snd/01/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:             
+  - ../../base
+  - ../../ffc-ffd-frontend-poc
+  - ../../ffc-ffd-backend-poc

--- a/services/ffc-ffd/snd/02/kustomization.yaml
+++ b/services/ffc-ffd/snd/02/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:             
+  - ../../base
+  - ../../ffc-ffd-frontend-poc
+  - ../../ffc-ffd-backend-poc

--- a/services/ffc-ffd/snd/03/kustomization.yaml
+++ b/services/ffc-ffd/snd/03/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:             
+  - ../../base
+  - ../../ffc-ffd-frontend-poc
+  - ../../ffc-ffd-backend-poc


### PR DESCRIPTION
Created flux files and folders for FFC-FFD (Alpha Testing) in SND1, 2 and 3.  They are for a backend and frontend service and were automatically generated using pipeline 'adp-flux-services-onboarding'

https://dev.azure.com/defragovuk/DEFRA-FFC/_build/results?buildId=430335&view=results

[AB#284393](https://dev.azure.com/defragovuk/93c65135-d16b-49d6-a191-4a5313532779/_workitems/edit/284393)

# Checklist (please delete before completing or setting auto-complete)
- [x] Story Work items associated (not Tasks)
- [ ] Successful testing run(s) link provided
- [x] Title pattern should be `{work item number}: {title}`
- [x] Description covers all the changes in the PR
- [ ] This PR contains documentation
- [ ] This PR contains tests


# **How does this PR make you feel**:
![gif](https://giphy.com/clips/santa-jingle-bells-christmas-discount-EcWmyeOIlYQ8FloLBO)
