### PR TITLE
287810: Fix image policy names for backend services

### DIFF
--- a/services/ffc/ffc-demo/ffc-demo-claim-service/pre-deploy/snd/02/image-policy.yaml
+++ b/services/ffc/ffc-demo/ffc-demo-claim-service/pre-deploy/snd/02/image-policy.yaml
@@ -1,7 +1,7 @@
 apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
 metadata:
-  name: ffc-demo-claim-service-dbmigration-snd-01
+  name: ffc-demo-claim-service-dbmigration-snd-02
   namespace: flux-config
 spec:
   imageRepositoryRef:

--- a/services/ffc/ffc-demo/ffc-demo-claim-service/pre-deploy/snd/03/image-policy.yaml
+++ b/services/ffc/ffc-demo/ffc-demo-claim-service/pre-deploy/snd/03/image-policy.yaml
@@ -1,7 +1,7 @@
 apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
 metadata:
-  name: ffc-demo-claim-service-dbmigration-snd-01
+  name: ffc-demo-claim-service-dbmigration-snd-03
   namespace: flux-config
 spec:
   imageRepositoryRef:

--- a/services/ffc/ffc-demo/ffc-demo-claim-service/pre-deploy/tst/02/image-policy.yaml
+++ b/services/ffc/ffc-demo/ffc-demo-claim-service/pre-deploy/tst/02/image-policy.yaml
@@ -1,7 +1,7 @@
 apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
 metadata:
-  name: ffc-demo-claim-service-dbmigration-tst-01
+  name: ffc-demo-claim-service-dbmigration-tst-02
   namespace: flux-config
 spec:
   imageRepositoryRef:

--- a/services/ffc/ffc-demo/ffc-demo-payment-service/pre-deploy/snd/02/image-policy.yaml
+++ b/services/ffc/ffc-demo/ffc-demo-payment-service/pre-deploy/snd/02/image-policy.yaml
@@ -1,7 +1,7 @@
 apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
 metadata:
-  name: ffc-demo-payment-service-dbmigration-snd-01
+  name: ffc-demo-payment-service-dbmigration-snd-02
   namespace: flux-config
 spec:
   imageRepositoryRef:

--- a/services/ffc/ffc-demo/ffc-demo-payment-service/pre-deploy/snd/03/image-policy.yaml
+++ b/services/ffc/ffc-demo/ffc-demo-payment-service/pre-deploy/snd/03/image-policy.yaml
@@ -1,7 +1,7 @@
 apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
 metadata:
-  name: ffc-demo-payment-service-dbmigration-snd-01
+  name: ffc-demo-payment-service-dbmigration-snd-03
   namespace: flux-config
 spec:
   imageRepositoryRef:

--- a/services/ffc/ffc-demo/ffc-demo-payment-service/pre-deploy/tst/02/image-policy.yaml
+++ b/services/ffc/ffc-demo/ffc-demo-payment-service/pre-deploy/tst/02/image-policy.yaml
@@ -1,7 +1,7 @@
 apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
 metadata:
-  name: ffc-demo-payment-service-dbmigration-tst-01
+  name: ffc-demo-payment-service-dbmigration-tst-02
   namespace: flux-config
 spec:
   imageRepositoryRef:

--- a/services/ffc/ffc-ffd/ffc-ffd-backend-poc/pre-deploy/snd/02/image-policy.yaml
+++ b/services/ffc/ffc-ffd/ffc-ffd-backend-poc/pre-deploy/snd/02/image-policy.yaml
@@ -1,7 +1,7 @@
 apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
 metadata:
-  name: ffc-ffd-backend-poc-dbmigration-snd-01
+  name: ffc-ffd-backend-poc-dbmigration-snd-02
   namespace: flux-config
 spec:
   imageRepositoryRef:

--- a/services/ffc/ffc-ffd/ffc-ffd-backend-poc/pre-deploy/snd/03/image-policy.yaml
+++ b/services/ffc/ffc-ffd/ffc-ffd-backend-poc/pre-deploy/snd/03/image-policy.yaml
@@ -1,7 +1,7 @@
 apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
 metadata:
-  name: ffc-ffd-backend-poc-dbmigration-snd-01
+  name: ffc-ffd-backend-poc-dbmigration-snd-03
   namespace: flux-config
 spec:
   imageRepositoryRef:


### PR DESCRIPTION
All SND pre-deploy image policies are pointing to SND1. This PR will fix the automation that generates the manifests.

[AB#287810](https://dev.azure.com/defragovuk/93c65135-d16b-49d6-a191-4a5313532779/_workitems/edit/287810)

# Checklist (please delete before completing or setting auto-complete)
- [x] Story Work items associated (not Tasks)
- [ ] Successful testing run(s) link provided
- [x] Title pattern should be `{work item number}: {title}`
- [x] Description covers all the changes in the PR
- [ ] This PR contains documentation
- [ ] This PR contains tests


# **How does this PR make you feel**:
![gif](https://media.giphy.com/media/zOvBKUUEERdNm/giphy.gif)
