### PR TITLE
267988: Updated ps-exec image policy

### DIFF
--- a/services/adp-platform/ps-exec-image-policy.yaml
+++ b/services/adp-platform/ps-exec-image-policy.yaml
@@ -1,7 +1,7 @@
 apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
 metadata:
-  name: powershell-executor
+  name: powershell-executor-ssv3
   namespace: flux-config
 spec:
   imageRepositoryRef:
@@ -9,4 +9,15 @@ spec:
   policy:
     numerical:
       order: asc
-      
+---
+apiVersion: image.toolkit.fluxcd.io/v1beta2
+kind: ImagePolicy
+metadata:
+  name: powershell-executor-ssv5
+  namespace: flux-config
+spec:
+  imageRepositoryRef:
+    name: powershell-executor
+  policy:
+    numerical:
+      order: asc

--- a/services/ffc/ffc-demo/ffc-demo-claim-service/pre-deploy/post-migration/dev/01/post-migration-script-patch.yaml
+++ b/services/ffc/ffc-demo/ffc-demo-claim-service/pre-deploy/post-migration/dev/01/post-migration-script-patch.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       containers:
       - name: ffc-demo-claim-service-post-dbmigration
-        image: ssvadpinfcr3401.azurecr.io/image/powershell-executor:424529 # {"$imagepolicy": "flux-config:powershell-executor"}
+        image: ssvadpinfcr5401.azurecr.io/image/powershell-executor:424529 # {"$imagepolicy": "flux-config:powershell-executor-ssv5"}
         env:
         - name: GIT_REPO_URL
           value: "https://github.com/DEFRA/adp-flux-services.git"

--- a/services/ffc/ffc-demo/ffc-demo-claim-service/pre-deploy/post-migration/prd/01/post-migration-script-patch.yaml
+++ b/services/ffc/ffc-demo/ffc-demo-claim-service/pre-deploy/post-migration/prd/01/post-migration-script-patch.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       containers:
       - name: ffc-demo-claim-service-post-dbmigration
-        image: ssvadpinfcr3401.azurecr.io/image/powershell-executor:424529 # {"$imagepolicy": "flux-config:powershell-executor"}
+        image: ssvadpinfcr5401.azurecr.io/image/powershell-executor:424529 # {"$imagepolicy": "flux-config:powershell-executor-ssv5"}
         env:
         - name: GIT_REPO_URL
           value: "https://github.com/DEFRA/adp-flux-services.git"

--- a/services/ffc/ffc-demo/ffc-demo-claim-service/pre-deploy/post-migration/pre/01/post-migration-script-patch.yaml
+++ b/services/ffc/ffc-demo/ffc-demo-claim-service/pre-deploy/post-migration/pre/01/post-migration-script-patch.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       containers:
       - name: ffc-demo-claim-service-post-dbmigration
-        image: ssvadpinfcr3401.azurecr.io/image/powershell-executor:424529 # {"$imagepolicy": "flux-config:powershell-executor"}
+        image: ssvadpinfcr5401.azurecr.io/image/powershell-executor:424529 # {"$imagepolicy": "flux-config:powershell-executor-ssv5"}
         env:
         - name: GIT_REPO_URL
           value: "https://github.com/DEFRA/adp-flux-services.git"

--- a/services/ffc/ffc-demo/ffc-demo-claim-service/pre-deploy/post-migration/snd/01/post-migration-script-patch.yaml
+++ b/services/ffc/ffc-demo/ffc-demo-claim-service/pre-deploy/post-migration/snd/01/post-migration-script-patch.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       containers:
       - name: ffc-demo-claim-service-post-dbmigration
-        image: ssvadpinfcr3401.azurecr.io/image/powershell-executor:424529 # {"$imagepolicy": "flux-config:powershell-executor"}
+        image: ssvadpinfcr3401.azurecr.io/image/powershell-executor:424529 # {"$imagepolicy": "flux-config:powershell-executor-ssv3"}
         env:
         - name: GIT_REPO_URL
           value: "https://github.com/DEFRA/adp-flux-services.git"

--- a/services/ffc/ffc-demo/ffc-demo-claim-service/pre-deploy/post-migration/snd/02/post-migration-script-patch.yaml
+++ b/services/ffc/ffc-demo/ffc-demo-claim-service/pre-deploy/post-migration/snd/02/post-migration-script-patch.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       containers:
       - name: ffc-demo-claim-service-post-dbmigration
-        image: ssvadpinfcr3401.azurecr.io/image/powershell-executor:424529 # {"$imagepolicy": "flux-config:powershell-executor"}
+        image: ssvadpinfcr3401.azurecr.io/image/powershell-executor:424529 # {"$imagepolicy": "flux-config:powershell-executor-ssv3"}
         env:
         - name: GIT_REPO_URL
           value: "https://github.com/DEFRA/adp-flux-services.git"

--- a/services/ffc/ffc-demo/ffc-demo-claim-service/pre-deploy/post-migration/snd/03/post-migration-script-patch.yaml
+++ b/services/ffc/ffc-demo/ffc-demo-claim-service/pre-deploy/post-migration/snd/03/post-migration-script-patch.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       containers:
       - name: ffc-demo-claim-service-post-dbmigration
-        image: ssvadpinfcr3401.azurecr.io/image/powershell-executor:424529 # {"$imagepolicy": "flux-config:powershell-executor"}
+        image: ssvadpinfcr3401.azurecr.io/image/powershell-executor:424529 # {"$imagepolicy": "flux-config:powershell-executor-ssv3"}
         env:
         - name: GIT_REPO_URL
           value: "https://github.com/DEFRA/adp-flux-services.git"

--- a/services/ffc/ffc-demo/ffc-demo-claim-service/pre-deploy/post-migration/tst/01/post-migration-script-patch.yaml
+++ b/services/ffc/ffc-demo/ffc-demo-claim-service/pre-deploy/post-migration/tst/01/post-migration-script-patch.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       containers:
       - name: ffc-demo-claim-service-post-dbmigration
-        image: ssvadpinfcr3401.azurecr.io/image/powershell-executor:424529 # {"$imagepolicy": "flux-config:powershell-executor"}
+        image: ssvadpinfcr5401.azurecr.io/image/powershell-executor:424529 # {"$imagepolicy": "flux-config:powershell-executor-ssv5"}
         env:
         - name: GIT_REPO_URL
           value: "https://github.com/DEFRA/adp-flux-services.git"

--- a/services/ffc/ffc-demo/ffc-demo-claim-service/pre-deploy/post-migration/tst/02/post-migration-script-patch.yaml
+++ b/services/ffc/ffc-demo/ffc-demo-claim-service/pre-deploy/post-migration/tst/02/post-migration-script-patch.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       containers:
       - name: ffc-demo-claim-service-post-dbmigration
-        image: ssvadpinfcr3401.azurecr.io/image/powershell-executor:424529 # {"$imagepolicy": "flux-config:powershell-executor"}
+        image: ssvadpinfcr5401.azurecr.io/image/powershell-executor:424529 # {"$imagepolicy": "flux-config:powershell-executor-ssv5"}
         env:
         - name: GIT_REPO_URL
           value: "https://github.com/DEFRA/adp-flux-services.git"

--- a/services/ffc/ffc-demo/ffc-demo-claim-service/pre-deploy/pre-migration/dev/01/pre-migration-script-patch.yaml
+++ b/services/ffc/ffc-demo/ffc-demo-claim-service/pre-deploy/pre-migration/dev/01/pre-migration-script-patch.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       containers:
       - name: ffc-demo-claim-service-pre-dbmigration
-        image: ssvadpinfcr3401.azurecr.io/image/powershell-executor:424529 # {"$imagepolicy": "flux-config:powershell-executor"}
+        image: ssvadpinfcr5401.azurecr.io/image/powershell-executor:424529 # {"$imagepolicy": "flux-config:powershell-executor-ssv5"}
         env:
         - name: GIT_REPO_URL
           value: "https://github.com/DEFRA/adp-flux-services.git"

--- a/services/ffc/ffc-demo/ffc-demo-claim-service/pre-deploy/pre-migration/prd/01/pre-migration-script-patch.yaml
+++ b/services/ffc/ffc-demo/ffc-demo-claim-service/pre-deploy/pre-migration/prd/01/pre-migration-script-patch.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       containers:
       - name: ffc-demo-claim-service-pre-dbmigration
-        image: ssvadpinfcr3401.azurecr.io/image/powershell-executor:424529 # {"$imagepolicy": "flux-config:powershell-executor"}
+        image: ssvadpinfcr5401.azurecr.io/image/powershell-executor:424529 # {"$imagepolicy": "flux-config:powershell-executor-ssv5"}
         env:
         - name: GIT_REPO_URL
           value: "https://github.com/DEFRA/adp-flux-services.git"

--- a/services/ffc/ffc-demo/ffc-demo-claim-service/pre-deploy/pre-migration/pre/01/pre-migration-script-patch.yaml
+++ b/services/ffc/ffc-demo/ffc-demo-claim-service/pre-deploy/pre-migration/pre/01/pre-migration-script-patch.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       containers:
       - name: ffc-demo-claim-service-pre-dbmigration
-        image: ssvadpinfcr3401.azurecr.io/image/powershell-executor:424529 # {"$imagepolicy": "flux-config:powershell-executor"}
+        image: ssvadpinfcr5401.azurecr.io/image/powershell-executor:424529 # {"$imagepolicy": "flux-config:powershell-executor-ssv5"}
         env:
         - name: GIT_REPO_URL
           value: "https://github.com/DEFRA/adp-flux-services.git"

--- a/services/ffc/ffc-demo/ffc-demo-claim-service/pre-deploy/pre-migration/snd/01/pre-migration-script-patch.yaml
+++ b/services/ffc/ffc-demo/ffc-demo-claim-service/pre-deploy/pre-migration/snd/01/pre-migration-script-patch.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       containers:
       - name: ffc-demo-claim-service-pre-dbmigration
-        image: ssvadpinfcr3401.azurecr.io/image/powershell-executor:424529 # {"$imagepolicy": "flux-config:powershell-executor"}
+        image: ssvadpinfcr3401.azurecr.io/image/powershell-executor:424529 # {"$imagepolicy": "flux-config:powershell-executor-ssv3"}
         env:
         - name: GIT_REPO_URL
           value: "https://github.com/DEFRA/adp-flux-services.git"

--- a/services/ffc/ffc-demo/ffc-demo-claim-service/pre-deploy/pre-migration/snd/02/pre-migration-script-patch.yaml
+++ b/services/ffc/ffc-demo/ffc-demo-claim-service/pre-deploy/pre-migration/snd/02/pre-migration-script-patch.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       containers:
       - name: ffc-demo-claim-service-pre-dbmigration
-        image: ssvadpinfcr3401.azurecr.io/image/powershell-executor:424529 # {"$imagepolicy": "flux-config:powershell-executor"}
+        image: ssvadpinfcr3401.azurecr.io/image/powershell-executor:424529 # {"$imagepolicy": "flux-config:powershell-executor-ssv3"}
         env:
         - name: GIT_REPO_URL
           value: "https://github.com/DEFRA/adp-flux-services.git"

--- a/services/ffc/ffc-demo/ffc-demo-claim-service/pre-deploy/pre-migration/snd/03/pre-migration-script-patch.yaml
+++ b/services/ffc/ffc-demo/ffc-demo-claim-service/pre-deploy/pre-migration/snd/03/pre-migration-script-patch.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       containers:
       - name: ffc-demo-claim-service-pre-dbmigration
-        image: ssvadpinfcr3401.azurecr.io/image/powershell-executor:424529 # {"$imagepolicy": "flux-config:powershell-executor"}
+        image: ssvadpinfcr3401.azurecr.io/image/powershell-executor:424529 # {"$imagepolicy": "flux-config:powershell-executor-ssv3"}
         env:
         - name: GIT_REPO_URL
           value: "https://github.com/DEFRA/adp-flux-services.git"

--- a/services/ffc/ffc-demo/ffc-demo-claim-service/pre-deploy/pre-migration/tst/01/pre-migration-script-patch.yaml
+++ b/services/ffc/ffc-demo/ffc-demo-claim-service/pre-deploy/pre-migration/tst/01/pre-migration-script-patch.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       containers:
       - name: ffc-demo-claim-service-pre-dbmigration
-        image: ssvadpinfcr3401.azurecr.io/image/powershell-executor:424529 # {"$imagepolicy": "flux-config:powershell-executor"}
+        image: ssvadpinfcr5401.azurecr.io/image/powershell-executor:424529 # {"$imagepolicy": "flux-config:powershell-executor-ssv5"}
         env:
         - name: GIT_REPO_URL
           value: "https://github.com/DEFRA/adp-flux-services.git"

--- a/services/ffc/ffc-demo/ffc-demo-claim-service/pre-deploy/pre-migration/tst/02/pre-migration-script-patch.yaml
+++ b/services/ffc/ffc-demo/ffc-demo-claim-service/pre-deploy/pre-migration/tst/02/pre-migration-script-patch.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       containers:
       - name: ffc-demo-claim-service-pre-dbmigration
-        image: ssvadpinfcr3401.azurecr.io/image/powershell-executor:424529 # {"$imagepolicy": "flux-config:powershell-executor"}
+        image: ssvadpinfcr5401.azurecr.io/image/powershell-executor:424529 # {"$imagepolicy": "flux-config:powershell-executor-ssv5"}
         env:
         - name: GIT_REPO_URL
           value: "https://github.com/DEFRA/adp-flux-services.git"

--- a/services/ffc/ffc-demo/ffc-demo-payment-service/pre-deploy/post-migration/dev/01/post-migration-script-patch.yaml
+++ b/services/ffc/ffc-demo/ffc-demo-payment-service/pre-deploy/post-migration/dev/01/post-migration-script-patch.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       containers:
       - name: ffc-demo-payment-service-post-dbmigration
-        image: ssvadpinfcr3401.azurecr.io/image/powershell-executor:424529 # {"$imagepolicy": "flux-config:powershell-executor"}
+        image: ssvadpinfcr5401.azurecr.io/image/powershell-executor:424529 # {"$imagepolicy": "flux-config:powershell-executor-ssv5"}
         env:
         - name: GIT_REPO_URL
           value: "https://github.com/DEFRA/adp-flux-services.git"

--- a/services/ffc/ffc-demo/ffc-demo-payment-service/pre-deploy/post-migration/prd/01/post-migration-script-patch.yaml
+++ b/services/ffc/ffc-demo/ffc-demo-payment-service/pre-deploy/post-migration/prd/01/post-migration-script-patch.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       containers:
       - name: ffc-demo-payment-service-post-dbmigration
-        image: ssvadpinfcr3401.azurecr.io/image/powershell-executor:424529 # {"$imagepolicy": "flux-config:powershell-executor"}
+        image: ssvadpinfcr5401.azurecr.io/image/powershell-executor:424529 # {"$imagepolicy": "flux-config:powershell-executor-ssv5"}
         env:
         - name: GIT_REPO_URL
           value: "https://github.com/DEFRA/adp-flux-services.git"

--- a/services/ffc/ffc-demo/ffc-demo-payment-service/pre-deploy/post-migration/pre/01/post-migration-script-patch.yaml
+++ b/services/ffc/ffc-demo/ffc-demo-payment-service/pre-deploy/post-migration/pre/01/post-migration-script-patch.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       containers:
       - name: ffc-demo-payment-service-post-dbmigration
-        image: ssvadpinfcr3401.azurecr.io/image/powershell-executor:424529 # {"$imagepolicy": "flux-config:powershell-executor"}
+        image: ssvadpinfcr5401.azurecr.io/image/powershell-executor:424529 # {"$imagepolicy": "flux-config:powershell-executor-ssv5"}
         env:
         - name: GIT_REPO_URL
           value: "https://github.com/DEFRA/adp-flux-services.git"

--- a/services/ffc/ffc-demo/ffc-demo-payment-service/pre-deploy/post-migration/snd/01/post-migration-script-patch.yaml
+++ b/services/ffc/ffc-demo/ffc-demo-payment-service/pre-deploy/post-migration/snd/01/post-migration-script-patch.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       containers:
       - name: ffc-demo-payment-service-post-dbmigration
-        image: ssvadpinfcr3401.azurecr.io/image/powershell-executor:424529 # {"$imagepolicy": "flux-config:powershell-executor"}
+        image: ssvadpinfcr3401.azurecr.io/image/powershell-executor:424529 # {"$imagepolicy": "flux-config:powershell-executor-ssv3"}
         env:
         - name: GIT_REPO_URL
           value: "https://github.com/DEFRA/adp-flux-services.git"

--- a/services/ffc/ffc-demo/ffc-demo-payment-service/pre-deploy/post-migration/snd/02/post-migration-script-patch.yaml
+++ b/services/ffc/ffc-demo/ffc-demo-payment-service/pre-deploy/post-migration/snd/02/post-migration-script-patch.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       containers:
       - name: ffc-demo-payment-service-post-dbmigration
-        image: ssvadpinfcr3401.azurecr.io/image/powershell-executor:424529 # {"$imagepolicy": "flux-config:powershell-executor"}
+        image: ssvadpinfcr3401.azurecr.io/image/powershell-executor:424529 # {"$imagepolicy": "flux-config:powershell-executor-ssv3"}
         env:
         - name: GIT_REPO_URL
           value: "https://github.com/DEFRA/adp-flux-services.git"

--- a/services/ffc/ffc-demo/ffc-demo-payment-service/pre-deploy/post-migration/snd/03/post-migration-script-patch.yaml
+++ b/services/ffc/ffc-demo/ffc-demo-payment-service/pre-deploy/post-migration/snd/03/post-migration-script-patch.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       containers:
       - name: ffc-demo-payment-service-post-dbmigration
-        image: ssvadpinfcr3401.azurecr.io/image/powershell-executor:424529 # {"$imagepolicy": "flux-config:powershell-executor"}
+        image: ssvadpinfcr3401.azurecr.io/image/powershell-executor:424529 # {"$imagepolicy": "flux-config:powershell-executor-ssv3"}
         env:
         - name: GIT_REPO_URL
           value: "https://github.com/DEFRA/adp-flux-services.git"

--- a/services/ffc/ffc-demo/ffc-demo-payment-service/pre-deploy/post-migration/tst/01/post-migration-script-patch.yaml
+++ b/services/ffc/ffc-demo/ffc-demo-payment-service/pre-deploy/post-migration/tst/01/post-migration-script-patch.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       containers:
       - name: ffc-demo-payment-service-post-dbmigration
-        image: ssvadpinfcr3401.azurecr.io/image/powershell-executor:424529 # {"$imagepolicy": "flux-config:powershell-executor"}
+        image: ssvadpinfcr5401.azurecr.io/image/powershell-executor:424529 # {"$imagepolicy": "flux-config:powershell-executor-ssv5"}
         env:
         - name: GIT_REPO_URL
           value: "https://github.com/DEFRA/adp-flux-services.git"

--- a/services/ffc/ffc-demo/ffc-demo-payment-service/pre-deploy/post-migration/tst/02/post-migration-script-patch.yaml
+++ b/services/ffc/ffc-demo/ffc-demo-payment-service/pre-deploy/post-migration/tst/02/post-migration-script-patch.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       containers:
       - name: ffc-demo-payment-service-post-dbmigration
-        image: ssvadpinfcr3401.azurecr.io/image/powershell-executor:424529 # {"$imagepolicy": "flux-config:powershell-executor"}
+        image: ssvadpinfcr5401.azurecr.io/image/powershell-executor:424529 # {"$imagepolicy": "flux-config:powershell-executor-ssv5"}
         env:
         - name: GIT_REPO_URL
           value: "https://github.com/DEFRA/adp-flux-services.git"

--- a/services/ffc/ffc-demo/ffc-demo-payment-service/pre-deploy/pre-migration/dev/01/pre-migration-script-patch.yaml
+++ b/services/ffc/ffc-demo/ffc-demo-payment-service/pre-deploy/pre-migration/dev/01/pre-migration-script-patch.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       containers:
       - name: ffc-demo-payment-service-pre-dbmigration
-        image: ssvadpinfcr3401.azurecr.io/image/powershell-executor:424529 # {"$imagepolicy": "flux-config:powershell-executor"}
+        image: ssvadpinfcr5401.azurecr.io/image/powershell-executor:424529 # {"$imagepolicy": "flux-config:powershell-executor-ssv5"}
         env:
         - name: GIT_REPO_URL
           value: "https://github.com/DEFRA/adp-flux-services.git"

--- a/services/ffc/ffc-demo/ffc-demo-payment-service/pre-deploy/pre-migration/prd/01/pre-migration-script-patch.yaml
+++ b/services/ffc/ffc-demo/ffc-demo-payment-service/pre-deploy/pre-migration/prd/01/pre-migration-script-patch.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       containers:
       - name: ffc-demo-payment-service-pre-dbmigration
-        image: ssvadpinfcr3401.azurecr.io/image/powershell-executor:424529 # {"$imagepolicy": "flux-config:powershell-executor"}
+        image: ssvadpinfcr5401.azurecr.io/image/powershell-executor:424529 # {"$imagepolicy": "flux-config:powershell-executor-ssv5"}
         env:
         - name: GIT_REPO_URL
           value: "https://github.com/DEFRA/adp-flux-services.git"

--- a/services/ffc/ffc-demo/ffc-demo-payment-service/pre-deploy/pre-migration/pre/01/pre-migration-script-patch.yaml
+++ b/services/ffc/ffc-demo/ffc-demo-payment-service/pre-deploy/pre-migration/pre/01/pre-migration-script-patch.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       containers:
       - name: ffc-demo-payment-service-pre-dbmigration
-        image: ssvadpinfcr3401.azurecr.io/image/powershell-executor:424529 # {"$imagepolicy": "flux-config:powershell-executor"}
+        image: ssvadpinfcr5401.azurecr.io/image/powershell-executor:424529 # {"$imagepolicy": "flux-config:powershell-executor-ssv5"}
         env:
         - name: GIT_REPO_URL
           value: "https://github.com/DEFRA/adp-flux-services.git"

--- a/services/ffc/ffc-demo/ffc-demo-payment-service/pre-deploy/pre-migration/snd/01/pre-migration-script-patch.yaml
+++ b/services/ffc/ffc-demo/ffc-demo-payment-service/pre-deploy/pre-migration/snd/01/pre-migration-script-patch.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       containers:
       - name: ffc-demo-payment-service-pre-dbmigration
-        image: ssvadpinfcr3401.azurecr.io/image/powershell-executor:424529 # {"$imagepolicy": "flux-config:powershell-executor"}
+        image: ssvadpinfcr3401.azurecr.io/image/powershell-executor:424529 # {"$imagepolicy": "flux-config:powershell-executor-ssv3"}
         env:
         - name: GIT_REPO_URL
           value: "https://github.com/DEFRA/adp-flux-services.git"

--- a/services/ffc/ffc-demo/ffc-demo-payment-service/pre-deploy/pre-migration/snd/02/pre-migration-script-patch.yaml
+++ b/services/ffc/ffc-demo/ffc-demo-payment-service/pre-deploy/pre-migration/snd/02/pre-migration-script-patch.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       containers:
       - name: ffc-demo-payment-service-pre-dbmigration
-        image: ssvadpinfcr3401.azurecr.io/image/powershell-executor:424529 # {"$imagepolicy": "flux-config:powershell-executor"}
+        image: ssvadpinfcr3401.azurecr.io/image/powershell-executor:424529 # {"$imagepolicy": "flux-config:powershell-executor-ssv3"}
         env:
         - name: GIT_REPO_URL
           value: "https://github.com/DEFRA/adp-flux-services.git"

--- a/services/ffc/ffc-demo/ffc-demo-payment-service/pre-deploy/pre-migration/snd/03/pre-migration-script-patch.yaml
+++ b/services/ffc/ffc-demo/ffc-demo-payment-service/pre-deploy/pre-migration/snd/03/pre-migration-script-patch.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       containers:
       - name: ffc-demo-payment-service-pre-dbmigration
-        image: ssvadpinfcr3401.azurecr.io/image/powershell-executor:424529 # {"$imagepolicy": "flux-config:powershell-executor"}
+        image: ssvadpinfcr3401.azurecr.io/image/powershell-executor:424529 # {"$imagepolicy": "flux-config:powershell-executor-ssv3"}
         env:
         - name: GIT_REPO_URL
           value: "https://github.com/DEFRA/adp-flux-services.git"

--- a/services/ffc/ffc-demo/ffc-demo-payment-service/pre-deploy/pre-migration/tst/01/pre-migration-script-patch.yaml
+++ b/services/ffc/ffc-demo/ffc-demo-payment-service/pre-deploy/pre-migration/tst/01/pre-migration-script-patch.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       containers:
       - name: ffc-demo-payment-service-pre-dbmigration
-        image: ssvadpinfcr3401.azurecr.io/image/powershell-executor:424529 # {"$imagepolicy": "flux-config:powershell-executor"}
+        image: ssvadpinfcr5401.azurecr.io/image/powershell-executor:424529 # {"$imagepolicy": "flux-config:powershell-executor-ssv5"}
         env:
         - name: GIT_REPO_URL
           value: "https://github.com/DEFRA/adp-flux-services.git"

--- a/services/ffc/ffc-demo/ffc-demo-payment-service/pre-deploy/pre-migration/tst/02/pre-migration-script-patch.yaml
+++ b/services/ffc/ffc-demo/ffc-demo-payment-service/pre-deploy/pre-migration/tst/02/pre-migration-script-patch.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       containers:
       - name: ffc-demo-payment-service-pre-dbmigration
-        image: ssvadpinfcr3401.azurecr.io/image/powershell-executor:424529 # {"$imagepolicy": "flux-config:powershell-executor"}
+        image: ssvadpinfcr5401.azurecr.io/image/powershell-executor:424529 # {"$imagepolicy": "flux-config:powershell-executor-ssv5"}
         env:
         - name: GIT_REPO_URL
           value: "https://github.com/DEFRA/adp-flux-services.git"

--- a/services/ffc/ffc-ffd/ffc-ffd-backend-poc/pre-deploy/post-migration/snd/01/post-migration-script-patch.yaml
+++ b/services/ffc/ffc-ffd/ffc-ffd-backend-poc/pre-deploy/post-migration/snd/01/post-migration-script-patch.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       containers:
       - name: ffc-ffd-backend-poc-post-dbmigration
-        image: ssvadpinfcr3401.azurecr.io/image/powershell-executor:424529 # {"$imagepolicy": "flux-config:powershell-executor"}
+        image: ssvadpinfcr3401.azurecr.io/image/powershell-executor:424529 # {"$imagepolicy": "flux-config:powershell-executor-ssv3"}
         env:
         - name: GIT_REPO_URL
           value: "https://github.com/DEFRA/adp-flux-services.git"

--- a/services/ffc/ffc-ffd/ffc-ffd-backend-poc/pre-deploy/post-migration/snd/02/post-migration-script-patch.yaml
+++ b/services/ffc/ffc-ffd/ffc-ffd-backend-poc/pre-deploy/post-migration/snd/02/post-migration-script-patch.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       containers:
       - name: ffc-ffd-backend-poc-post-dbmigration
-        image: ssvadpinfcr3401.azurecr.io/image/powershell-executor:424529 # {"$imagepolicy": "flux-config:powershell-executor"}
+        image: ssvadpinfcr3401.azurecr.io/image/powershell-executor:424529 # {"$imagepolicy": "flux-config:powershell-executor-ssv3"}
         env:
         - name: GIT_REPO_URL
           value: "https://github.com/DEFRA/adp-flux-services.git"

--- a/services/ffc/ffc-ffd/ffc-ffd-backend-poc/pre-deploy/post-migration/snd/03/post-migration-script-patch.yaml
+++ b/services/ffc/ffc-ffd/ffc-ffd-backend-poc/pre-deploy/post-migration/snd/03/post-migration-script-patch.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       containers:
       - name: ffc-ffd-backend-poc-post-dbmigration
-        image: ssvadpinfcr3401.azurecr.io/image/powershell-executor:424529 # {"$imagepolicy": "flux-config:powershell-executor"}
+        image: ssvadpinfcr3401.azurecr.io/image/powershell-executor:424529 # {"$imagepolicy": "flux-config:powershell-executor-ssv3"}
         env:
         - name: GIT_REPO_URL
           value: "https://github.com/DEFRA/adp-flux-services.git"

--- a/services/ffc/ffc-ffd/ffc-ffd-backend-poc/pre-deploy/pre-migration/snd/01/pre-migration-script-patch.yaml
+++ b/services/ffc/ffc-ffd/ffc-ffd-backend-poc/pre-deploy/pre-migration/snd/01/pre-migration-script-patch.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       containers:
       - name: ffc-ffd-backend-poc-pre-dbmigration
-        image: ssvadpinfcr3401.azurecr.io/image/powershell-executor:424529 # {"$imagepolicy": "flux-config:powershell-executor"}
+        image: ssvadpinfcr3401.azurecr.io/image/powershell-executor:424529 # {"$imagepolicy": "flux-config:powershell-executor-ssv3"}
         env:
         - name: GIT_REPO_URL
           value: "https://github.com/DEFRA/adp-flux-services.git"

--- a/services/ffc/ffc-ffd/ffc-ffd-backend-poc/pre-deploy/pre-migration/snd/02/pre-migration-script-patch.yaml
+++ b/services/ffc/ffc-ffd/ffc-ffd-backend-poc/pre-deploy/pre-migration/snd/02/pre-migration-script-patch.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       containers:
       - name: ffc-ffd-backend-poc-pre-dbmigration
-        image: ssvadpinfcr3401.azurecr.io/image/powershell-executor:424529 # {"$imagepolicy": "flux-config:powershell-executor"}
+        image: ssvadpinfcr3401.azurecr.io/image/powershell-executor:424529 # {"$imagepolicy": "flux-config:powershell-executor-ssv3"}
         env:
         - name: GIT_REPO_URL
           value: "https://github.com/DEFRA/adp-flux-services.git"

--- a/services/ffc/ffc-ffd/ffc-ffd-backend-poc/pre-deploy/pre-migration/snd/03/pre-migration-script-patch.yaml
+++ b/services/ffc/ffc-ffd/ffc-ffd-backend-poc/pre-deploy/pre-migration/snd/03/pre-migration-script-patch.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       containers:
       - name: ffc-ffd-backend-poc-pre-dbmigration
-        image: ssvadpinfcr3401.azurecr.io/image/powershell-executor:424529 # {"$imagepolicy": "flux-config:powershell-executor"}
+        image: ssvadpinfcr3401.azurecr.io/image/powershell-executor:424529 # {"$imagepolicy": "flux-config:powershell-executor-ssv3"}
         env:
         - name: GIT_REPO_URL
           value: "https://github.com/DEFRA/adp-flux-services.git"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
If this PR closes an issue, add '<[AB#213700](https://dev.azure.com/defragovuk/93c65135-d16b-49d6-a191-4a5313532779/_workitems/edit/213700)>' somewhere in the PR summary. As a minimum, please *always* link to the relevant work items e.g. [AB#213700](https://dev.azure.com/defragovuk/93c65135-d16b-49d6-a191-4a5313532779/_workitems/edit/213700) (work item number in Azure DevOps). Follow the format below carefully, guidance found here: https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops. Note: The Title pattern should be `{work item number}: {title}` -->

# **What this PR does / why we need it**:
This PR contains the changes to separate image policies for powershell executor image and reference appropriately based on environments.
[AB#267988](https://dev.azure.com/defragovuk/93c65135-d16b-49d6-a191-4a5313532779/_workitems/edit/267988)

# **Special notes for your reviewer**
*Any specific actions or notes on review?*

# Testing
*Any relevant testing information and pipeline runs.*

# Checklist (please delete before completing or setting auto-complete)
- [x] Story Work items associated (not Tasks)
- [ ] Successful testing run(s) link provided
- [x] Title pattern should be `{work item number}: {title}`
- [x] Description covers all the changes in the PR
- [ ] This PR contains documentation
- [ ] This PR contains tests


# **How does this PR make you feel**:
![TedStrikerSweating-AirplaneGIF](https://github.com/DEFRA/adp-flux-services/assets/119388966/5dfc6f19-2db5-4e79-a52a-14c6ec4aa245)

