### PR TITLE
299942: Added labels for ADP Portal Dashboards for flux plugin

### DIFF
--- a/services/eutd/eutd-trade-exports-ai/base/helm-repository.yaml
+++ b/services/eutd/eutd-trade-exports-ai/base/helm-repository.yaml
@@ -3,6 +3,8 @@ kind: HelmRepository
 metadata:
   name: eutd-trade-exports-ai-helm-repo
   namespace: flux-config
+  labels:
+    backstage.io/kubernetes-team: eutd-trade-exports-ai
 spec:
   type: oci
   interval: 5m

--- a/services/eutd/eutd-trade-exports-ai/base/patch/kustomize.yaml
+++ b/services/eutd/eutd-trade-exports-ai/base/patch/kustomize.yaml
@@ -3,6 +3,8 @@ kind: Kustomization
 metadata:
   name: eutd-trade-exports-ai-base
   namespace: flux-config
+  labels:
+    backstage.io/kubernetes-team: eutd-trade-exports-ai  
 spec:
   sourceRef:
     kind: GitRepository

--- a/services/eutd/eutd-trade-exports-ai/trade-exports-packinglistai-ui/deploy-kustomize.yaml
+++ b/services/eutd/eutd-trade-exports-ai/trade-exports-packinglistai-ui/deploy-kustomize.yaml
@@ -3,6 +3,9 @@ kind: Kustomization
 metadata:
   name: trade-exports-packinglistai-ui-deploy
   namespace: flux-config
+  labels:
+    backstage.io/kubernetes-id: trade-exports-packinglistai-ui
+    backstage.io/kubernetes-team: eutd-trade-exports-ai
 spec:
   dependsOn:
     - name: trade-exports-packinglistai-ui-infra

--- a/services/eutd/eutd-trade-exports-ai/trade-exports-packinglistai-ui/deploy/base/helm-release.yaml
+++ b/services/eutd/eutd-trade-exports-ai/trade-exports-packinglistai-ui/deploy/base/helm-release.yaml
@@ -3,6 +3,9 @@ kind: HelmRelease
 metadata:
   name: trade-exports-packinglistai-ui
   namespace: flux-config
+  labels:
+    backstage.io/kubernetes-id: trade-exports-packinglistai-ui
+    backstage.io/kubernetes-team: eutd-trade-exports-ai
 spec:
   releaseName: trade-exports-packinglistai-ui
   chart:

--- a/services/eutd/eutd-trade-exports-ai/trade-exports-packinglistai-ui/infra-kustomize.yaml
+++ b/services/eutd/eutd-trade-exports-ai/trade-exports-packinglistai-ui/infra-kustomize.yaml
@@ -3,6 +3,9 @@ kind: Kustomization
 metadata:
   name: trade-exports-packinglistai-ui-infra
   namespace: flux-config
+  labels:
+    backstage.io/kubernetes-id: trade-exports-packinglistai-ui
+    backstage.io/kubernetes-team: eutd-trade-exports-ai
 spec:
   sourceRef:
     kind: GitRepository

--- a/services/eutd/eutd-trade-exports-ai/trade-exports-packinglistai-ui/infra/base/aso-helm-release.yaml
+++ b/services/eutd/eutd-trade-exports-ai/trade-exports-packinglistai-ui/infra/base/aso-helm-release.yaml
@@ -3,6 +3,9 @@ kind: HelmRelease
 metadata:
   name: trade-exports-packinglistai-ui-infra
   namespace: flux-config
+  labels:
+    backstage.io/kubernetes-id: trade-exports-packinglistai-ui
+    backstage.io/kubernetes-team: eutd-trade-exports-ai
 spec:
   releaseName: trade-exports-packinglistai-ui-infra
   chart:

--- a/services/eutd/eutd-trade-exports-ai/trade-exports-packinglistai-ui/infra/base/image-repository.yaml
+++ b/services/eutd/eutd-trade-exports-ai/trade-exports-packinglistai-ui/infra/base/image-repository.yaml
@@ -3,6 +3,9 @@ kind: ImageRepository
 metadata:
   name: trade-exports-packinglistai-ui
   namespace: flux-config
+  labels:
+    backstage.io/kubernetes-id: trade-exports-packinglistai-ui
+    backstage.io/kubernetes-team: eutd-trade-exports-ai
 spec:
   image: ${APPLICATION_ACR_NAME}.azurecr.io/image/trade-exports-packinglistai-ui
   interval: 5m0s

--- a/services/eutd/eutd-trade-exports-ai/trade-exports-packinglistai-ui/infra/snd/01/image-policy.yaml
+++ b/services/eutd/eutd-trade-exports-ai/trade-exports-packinglistai-ui/infra/snd/01/image-policy.yaml
@@ -3,6 +3,9 @@ kind: ImagePolicy
 metadata:
   name: trade-exports-packinglistai-ui-snd-01
   namespace: flux-config
+  labels:
+    backstage.io/kubernetes-id: trade-exports-packinglistai-ui
+    backstage.io/kubernetes-team: eutd-trade-exports-ai
 spec:
   imageRepositoryRef:
     name: trade-exports-packinglistai-ui

--- a/services/eutd/eutd-trade-exports-ai/trade-exports-packinglistai-ui/infra/snd/02/image-policy.yaml
+++ b/services/eutd/eutd-trade-exports-ai/trade-exports-packinglistai-ui/infra/snd/02/image-policy.yaml
@@ -3,6 +3,9 @@ kind: ImagePolicy
 metadata:
   name: trade-exports-packinglistai-ui-snd-02
   namespace: flux-config
+  labels:
+    backstage.io/kubernetes-id: trade-exports-packinglistai-ui
+    backstage.io/kubernetes-team: eutd-trade-exports-ai
 spec:
   imageRepositoryRef:
     name: trade-exports-packinglistai-ui

--- a/services/eutd/eutd-trade-exports-ai/trade-exports-packinglistai-ui/infra/snd/03/image-policy.yaml
+++ b/services/eutd/eutd-trade-exports-ai/trade-exports-packinglistai-ui/infra/snd/03/image-policy.yaml
@@ -3,6 +3,9 @@ kind: ImagePolicy
 metadata:
   name: trade-exports-packinglistai-ui-snd-03
   namespace: flux-config
+  labels:
+    backstage.io/kubernetes-id: trade-exports-packinglistai-ui
+    backstage.io/kubernetes-team: eutd-trade-exports-ai
 spec:
   imageRepositoryRef:
     name: trade-exports-packinglistai-ui

--- a/services/ffc/ffc-demo/base/helm-repository.yaml
+++ b/services/ffc/ffc-demo/base/helm-repository.yaml
@@ -3,6 +3,8 @@ kind: HelmRepository
 metadata:
   name: ffc-demo-helm-repo
   namespace: flux-config
+  labels:
+    backstage.io/kubernetes-team: ffc-demo
 spec:
   type: oci
   interval: 5m

--- a/services/ffc/ffc-demo/base/patch/kustomize.yaml
+++ b/services/ffc/ffc-demo/base/patch/kustomize.yaml
@@ -3,6 +3,8 @@ kind: Kustomization
 metadata:
   name: ffc-demo-base
   namespace: flux-config
+  labels:
+    backstage.io/kubernetes-team: ffc-demo  
 spec:
   sourceRef:
     kind: GitRepository

--- a/services/ffc/ffc-demo/ffc-demo-calculation-service/deploy-kustomize.yaml
+++ b/services/ffc/ffc-demo/ffc-demo-calculation-service/deploy-kustomize.yaml
@@ -3,6 +3,9 @@ kind: Kustomization
 metadata:
   name: ffc-demo-calculation-service-deploy
   namespace: flux-config
+  labels:
+    backstage.io/kubernetes-id: ffc-demo-calculation-service
+    backstage.io/kubernetes-team: ffc-demo
 spec:
   dependsOn:
     - name: ffc-demo-calculation-service-infra

--- a/services/ffc/ffc-demo/ffc-demo-calculation-service/deploy/base/helm-release.yaml
+++ b/services/ffc/ffc-demo/ffc-demo-calculation-service/deploy/base/helm-release.yaml
@@ -3,6 +3,9 @@ kind: HelmRelease
 metadata:
   name: ffc-demo-calculation-service
   namespace: flux-config
+  labels:
+    backstage.io/kubernetes-id: ffc-demo-calculation-service
+    backstage.io/kubernetes-team: ffc-demo
 spec:
   releaseName: ffc-demo-calculation-service
   chart:

--- a/services/ffc/ffc-demo/ffc-demo-calculation-service/infra-kustomize.yaml
+++ b/services/ffc/ffc-demo/ffc-demo-calculation-service/infra-kustomize.yaml
@@ -3,6 +3,9 @@ kind: Kustomization
 metadata:
   name: ffc-demo-calculation-service-infra
   namespace: flux-config
+  labels:
+    backstage.io/kubernetes-id: ffc-demo-calculation-service
+    backstage.io/kubernetes-team: ffc-demo
 spec:
   sourceRef:
     kind: GitRepository

--- a/services/ffc/ffc-demo/ffc-demo-calculation-service/infra/base/aso-helm-release.yaml
+++ b/services/ffc/ffc-demo/ffc-demo-calculation-service/infra/base/aso-helm-release.yaml
@@ -3,6 +3,9 @@ kind: HelmRelease
 metadata:
   name: ffc-demo-calculation-service-infra
   namespace: flux-config
+  labels:
+    backstage.io/kubernetes-id: ffc-demo-calculation-service
+    backstage.io/kubernetes-team: ffc-demo
 spec:
   releaseName: ffc-demo-calculation-service-infra
   chart:

--- a/services/ffc/ffc-demo/ffc-demo-calculation-service/infra/base/image-repository.yaml
+++ b/services/ffc/ffc-demo/ffc-demo-calculation-service/infra/base/image-repository.yaml
@@ -3,6 +3,9 @@ kind: ImageRepository
 metadata:
   name: ffc-demo-calculation-service
   namespace: flux-config
+  labels:
+    backstage.io/kubernetes-id: ffc-demo-calculation-service
+    backstage.io/kubernetes-team: ffc-demo
 spec:
   image: ${APPLICATION_ACR_NAME}.azurecr.io/image/ffc-demo-calculation-service
   interval: 5m0s

--- a/services/ffc/ffc-demo/ffc-demo-calculation-service/infra/dev/01/image-policy.yaml
+++ b/services/ffc/ffc-demo/ffc-demo-calculation-service/infra/dev/01/image-policy.yaml
@@ -3,6 +3,9 @@ kind: ImagePolicy
 metadata:
   name: ffc-demo-calculation-service-dev-01
   namespace: flux-config
+  labels:
+    backstage.io/kubernetes-id: ffc-demo-calculation-service
+    backstage.io/kubernetes-team: ffc-demo
 spec:
   imageRepositoryRef:
     name: ffc-demo-calculation-service

--- a/services/ffc/ffc-demo/ffc-demo-calculation-service/infra/prd/01/image-policy.yaml
+++ b/services/ffc/ffc-demo/ffc-demo-calculation-service/infra/prd/01/image-policy.yaml
@@ -3,6 +3,9 @@ kind: ImagePolicy
 metadata:
   name: ffc-demo-calculation-service-prd-01
   namespace: flux-config
+  labels:
+    backstage.io/kubernetes-id: ffc-demo-calculation-service
+    backstage.io/kubernetes-team: ffc-demo
 spec:
   imageRepositoryRef:
     name: ffc-demo-calculation-service

--- a/services/ffc/ffc-demo/ffc-demo-calculation-service/infra/pre/01/image-policy.yaml
+++ b/services/ffc/ffc-demo/ffc-demo-calculation-service/infra/pre/01/image-policy.yaml
@@ -3,6 +3,9 @@ kind: ImagePolicy
 metadata:
   name: ffc-demo-calculation-service-pre-01
   namespace: flux-config
+  labels:
+    backstage.io/kubernetes-id: ffc-demo-calculation-service
+    backstage.io/kubernetes-team: ffc-demo
 spec:
   imageRepositoryRef:
     name: ffc-demo-calculation-service

--- a/services/ffc/ffc-demo/ffc-demo-calculation-service/infra/snd/01/image-policy.yaml
+++ b/services/ffc/ffc-demo/ffc-demo-calculation-service/infra/snd/01/image-policy.yaml
@@ -3,6 +3,9 @@ kind: ImagePolicy
 metadata:
   name: ffc-demo-calculation-service-snd-01
   namespace: flux-config
+  labels:
+    backstage.io/kubernetes-id: ffc-demo-calculation-service
+    backstage.io/kubernetes-team: ffc-demo
 spec:
   imageRepositoryRef:
     name: ffc-demo-calculation-service

--- a/services/ffc/ffc-demo/ffc-demo-calculation-service/infra/snd/02/image-policy.yaml
+++ b/services/ffc/ffc-demo/ffc-demo-calculation-service/infra/snd/02/image-policy.yaml
@@ -3,6 +3,9 @@ kind: ImagePolicy
 metadata:
   name: ffc-demo-calculation-service-snd-02
   namespace: flux-config
+  labels:
+    backstage.io/kubernetes-id: ffc-demo-calculation-service
+    backstage.io/kubernetes-team: ffc-demo
 spec:
   imageRepositoryRef:
     name: ffc-demo-calculation-service

--- a/services/ffc/ffc-demo/ffc-demo-calculation-service/infra/snd/03/image-policy.yaml
+++ b/services/ffc/ffc-demo/ffc-demo-calculation-service/infra/snd/03/image-policy.yaml
@@ -3,6 +3,9 @@ kind: ImagePolicy
 metadata:
   name: ffc-demo-calculation-service-snd-03
   namespace: flux-config
+  labels:
+    backstage.io/kubernetes-id: ffc-demo-calculation-service
+    backstage.io/kubernetes-team: ffc-demo
 spec:
   imageRepositoryRef:
     name: ffc-demo-calculation-service

--- a/services/ffc/ffc-demo/ffc-demo-calculation-service/infra/tst/01/image-policy.yaml
+++ b/services/ffc/ffc-demo/ffc-demo-calculation-service/infra/tst/01/image-policy.yaml
@@ -3,6 +3,9 @@ kind: ImagePolicy
 metadata:
   name: ffc-demo-calculation-service-tst-01
   namespace: flux-config
+  labels:
+    backstage.io/kubernetes-id: ffc-demo-calculation-service
+    backstage.io/kubernetes-team: ffc-demo
 spec:
   imageRepositoryRef:
     name: ffc-demo-calculation-service

--- a/services/ffc/ffc-demo/ffc-demo-calculation-service/infra/tst/02/image-policy.yaml
+++ b/services/ffc/ffc-demo/ffc-demo-calculation-service/infra/tst/02/image-policy.yaml
@@ -3,6 +3,9 @@ kind: ImagePolicy
 metadata:
   name: ffc-demo-calculation-service-tst-02
   namespace: flux-config
+  labels:
+    backstage.io/kubernetes-id: ffc-demo-calculation-service
+    backstage.io/kubernetes-team: ffc-demo
 spec:
   imageRepositoryRef:
     name: ffc-demo-calculation-service

--- a/services/ffc/ffc-demo/ffc-demo-claim-service/deploy-kustomize.yaml
+++ b/services/ffc/ffc-demo/ffc-demo-claim-service/deploy-kustomize.yaml
@@ -3,6 +3,9 @@ kind: Kustomization
 metadata:
   name: ffc-demo-claim-service-deploy
   namespace: flux-config
+  labels:
+    backstage.io/kubernetes-id: ffc-demo-claim-service
+    backstage.io/kubernetes-team: ffc-demo  
 spec:
   dependsOn:
     - name: ffc-demo-claim-service-pre-deploy

--- a/services/ffc/ffc-demo/ffc-demo-claim-service/infra-kustomize.yaml
+++ b/services/ffc/ffc-demo/ffc-demo-claim-service/infra-kustomize.yaml
@@ -3,6 +3,9 @@ kind: Kustomization
 metadata:
   name: ffc-demo-claim-service-infra
   namespace: flux-config
+  labels:
+    backstage.io/kubernetes-id: ffc-demo-claim-service
+    backstage.io/kubernetes-team: ffc-demo  
 spec:
   sourceRef:
     kind: GitRepository

--- a/services/ffc/ffc-demo/ffc-demo-claim-service/infra/base/aso-helm-release.yaml
+++ b/services/ffc/ffc-demo/ffc-demo-claim-service/infra/base/aso-helm-release.yaml
@@ -3,6 +3,9 @@ kind: HelmRelease
 metadata:
   name: ffc-demo-claim-service-infra
   namespace: flux-config
+  labels:
+    backstage.io/kubernetes-id: ffc-demo-claim-service
+    backstage.io/kubernetes-team: ffc-demo
 spec:
   releaseName: ffc-demo-claim-service-infra
   chart:

--- a/services/ffc/ffc-demo/ffc-demo-claim-service/infra/base/image-repository.yaml
+++ b/services/ffc/ffc-demo/ffc-demo-claim-service/infra/base/image-repository.yaml
@@ -3,6 +3,9 @@ kind: ImageRepository
 metadata:
   name: ffc-demo-claim-service
   namespace: flux-config
+  labels:
+    backstage.io/kubernetes-id: ffc-demo-claim-service
+    backstage.io/kubernetes-team: ffc-demo
 spec:
   image: ${APPLICATION_ACR_NAME}.azurecr.io/image/ffc-demo-claim-service
   interval: 5m0s

--- a/services/ffc/ffc-demo/ffc-demo-claim-service/infra/dev/01/image-policy.yaml
+++ b/services/ffc/ffc-demo/ffc-demo-claim-service/infra/dev/01/image-policy.yaml
@@ -3,6 +3,9 @@ kind: ImagePolicy
 metadata:
   name: ffc-demo-claim-service-dev-01
   namespace: flux-config
+  labels:
+    backstage.io/kubernetes-id: ffc-demo-claim-service
+    backstage.io/kubernetes-team: ffc-demo
 spec:
   imageRepositoryRef:
     name: ffc-demo-claim-service

--- a/services/ffc/ffc-demo/ffc-demo-claim-service/infra/prd/01/image-policy.yaml
+++ b/services/ffc/ffc-demo/ffc-demo-claim-service/infra/prd/01/image-policy.yaml
@@ -3,6 +3,9 @@ kind: ImagePolicy
 metadata:
   name: ffc-demo-claim-service-prd-01
   namespace: flux-config
+  labels:
+    backstage.io/kubernetes-id: ffc-demo-claim-service
+    backstage.io/kubernetes-team: ffc-demo
 spec:
   imageRepositoryRef:
     name: ffc-demo-claim-service

--- a/services/ffc/ffc-demo/ffc-demo-claim-service/infra/pre/01/image-policy.yaml
+++ b/services/ffc/ffc-demo/ffc-demo-claim-service/infra/pre/01/image-policy.yaml
@@ -3,6 +3,9 @@ kind: ImagePolicy
 metadata:
   name: ffc-demo-claim-service-pre-01
   namespace: flux-config
+  labels:
+    backstage.io/kubernetes-id: ffc-demo-claim-service
+    backstage.io/kubernetes-team: ffc-demo
 spec:
   imageRepositoryRef:
     name: ffc-demo-claim-service

--- a/services/ffc/ffc-demo/ffc-demo-claim-service/infra/snd/01/image-policy.yaml
+++ b/services/ffc/ffc-demo/ffc-demo-claim-service/infra/snd/01/image-policy.yaml
@@ -3,6 +3,9 @@ kind: ImagePolicy
 metadata:
   name: ffc-demo-claim-service-snd-01
   namespace: flux-config
+  labels:
+    backstage.io/kubernetes-id: ffc-demo-claim-service
+    backstage.io/kubernetes-team: ffc-demo
 spec:
   imageRepositoryRef:
     name: ffc-demo-claim-service

--- a/services/ffc/ffc-demo/ffc-demo-claim-service/infra/snd/02/image-policy.yaml
+++ b/services/ffc/ffc-demo/ffc-demo-claim-service/infra/snd/02/image-policy.yaml
@@ -3,6 +3,9 @@ kind: ImagePolicy
 metadata:
   name: ffc-demo-claim-service-snd-02
   namespace: flux-config
+  labels:
+    backstage.io/kubernetes-id: ffc-demo-claim-service
+    backstage.io/kubernetes-team: ffc-demo
 spec:
   imageRepositoryRef:
     name: ffc-demo-claim-service

--- a/services/ffc/ffc-demo/ffc-demo-claim-service/infra/snd/03/image-policy.yaml
+++ b/services/ffc/ffc-demo/ffc-demo-claim-service/infra/snd/03/image-policy.yaml
@@ -3,6 +3,9 @@ kind: ImagePolicy
 metadata:
   name: ffc-demo-claim-service-snd-03
   namespace: flux-config
+  labels:
+    backstage.io/kubernetes-id: ffc-demo-claim-service
+    backstage.io/kubernetes-team: ffc-demo
 spec:
   imageRepositoryRef:
     name: ffc-demo-claim-service

--- a/services/ffc/ffc-demo/ffc-demo-claim-service/infra/tst/01/image-policy.yaml
+++ b/services/ffc/ffc-demo/ffc-demo-claim-service/infra/tst/01/image-policy.yaml
@@ -3,6 +3,9 @@ kind: ImagePolicy
 metadata:
   name: ffc-demo-claim-service-tst-01
   namespace: flux-config
+  labels:
+    backstage.io/kubernetes-id: ffc-demo-claim-service
+    backstage.io/kubernetes-team: ffc-demo
 spec:
   imageRepositoryRef:
     name: ffc-demo-claim-service

--- a/services/ffc/ffc-demo/ffc-demo-claim-service/infra/tst/02/image-policy.yaml
+++ b/services/ffc/ffc-demo/ffc-demo-claim-service/infra/tst/02/image-policy.yaml
@@ -3,6 +3,9 @@ kind: ImagePolicy
 metadata:
   name: ffc-demo-claim-service-tst-02
   namespace: flux-config
+  labels:
+    backstage.io/kubernetes-id: ffc-demo-claim-service
+    backstage.io/kubernetes-team: ffc-demo
 spec:
   imageRepositoryRef:
     name: ffc-demo-claim-service

--- a/services/ffc/ffc-demo/ffc-demo-claim-service/pre-deploy-kustomize.yaml
+++ b/services/ffc/ffc-demo/ffc-demo-claim-service/pre-deploy-kustomize.yaml
@@ -3,6 +3,9 @@ kind: Kustomization
 metadata:
   name: ffc-demo-claim-service-pre-deploy
   namespace: flux-config
+  labels:
+    backstage.io/kubernetes-id: ffc-demo-claim-service
+    backstage.io/kubernetes-team: ffc-demo  
 spec:
   dependsOn:
     - name: ffc-demo-claim-service-infra

--- a/services/ffc/ffc-demo/ffc-demo-claim-service/pre-deploy/migration-kustomize.yaml
+++ b/services/ffc/ffc-demo/ffc-demo-claim-service/pre-deploy/migration-kustomize.yaml
@@ -3,6 +3,9 @@ kind: Kustomization
 metadata:
   name: ffc-demo-claim-service-pre-deploy-migration
   namespace: flux-config
+  labels:
+    backstage.io/kubernetes-id: ffc-demo-claim-service
+    backstage.io/kubernetes-team: ffc-demo
 spec:
   dependsOn:
     - name: ffc-demo-claim-service-pre-deploy-pre-migration

--- a/services/ffc/ffc-demo/ffc-demo-claim-service/pre-deploy/migration/base/image-repository-dbmigration.yaml
+++ b/services/ffc/ffc-demo/ffc-demo-claim-service/pre-deploy/migration/base/image-repository-dbmigration.yaml
@@ -4,6 +4,9 @@ kind: ImageRepository
 metadata:
   name: ffc-demo-claim-service-dbmigration
   namespace: flux-config
+  labels:
+    backstage.io/kubernetes-id: ffc-demo-claim-service
+    backstage.io/kubernetes-team: ffc-demo
 spec:
   image: ${APPLICATION_ACR_NAME}.azurecr.io/image/ffc-demo-claim-service-dbmigration
   interval: 5m0s

--- a/services/ffc/ffc-demo/ffc-demo-claim-service/pre-deploy/migration/base/migration.job.yaml
+++ b/services/ffc/ffc-demo/ffc-demo-claim-service/pre-deploy/migration/base/migration.job.yaml
@@ -5,11 +5,15 @@ metadata:
   namespace: ffc-demo
   labels:
     azure.workload.identity/use: "true"
+    backstage.io/kubernetes-id: ffc-demo-claim-service
+    backstage.io/kubernetes-team: ffc-demo
 spec:
   template:
     metadata:
       labels:
         azure.workload.identity/use: "true"
+        backstage.io/kubernetes-id: ffc-demo-claim-service
+        backstage.io/kubernetes-team: ffc-demo 
     spec:
       serviceAccountName: ${TEAM_NAMESPACE}
       restartPolicy: Never

--- a/services/ffc/ffc-demo/ffc-demo-claim-service/pre-deploy/migration/dev/01/image-policy.yaml
+++ b/services/ffc/ffc-demo/ffc-demo-claim-service/pre-deploy/migration/dev/01/image-policy.yaml
@@ -3,6 +3,9 @@ kind: ImagePolicy
 metadata:
   name: ffc-demo-claim-service-dbmigration-dev-01
   namespace: flux-config
+  labels:
+    backstage.io/kubernetes-id: ffc-demo-claim-service
+    backstage.io/kubernetes-team: ffc-demo
 spec:
   imageRepositoryRef:
     name: ffc-demo-claim-service-dbmigration

--- a/services/ffc/ffc-demo/ffc-demo-claim-service/pre-deploy/migration/prd/01/image-policy.yaml
+++ b/services/ffc/ffc-demo/ffc-demo-claim-service/pre-deploy/migration/prd/01/image-policy.yaml
@@ -3,6 +3,9 @@ kind: ImagePolicy
 metadata:
   name: ffc-demo-claim-service-dbmigration-prd-01
   namespace: flux-config
+  labels:
+    backstage.io/kubernetes-id: ffc-demo-claim-service
+    backstage.io/kubernetes-team: ffc-demo
 spec:
   imageRepositoryRef:
     name: ffc-demo-claim-service-dbmigration

--- a/services/ffc/ffc-demo/ffc-demo-claim-service/pre-deploy/migration/pre/01/image-policy.yaml
+++ b/services/ffc/ffc-demo/ffc-demo-claim-service/pre-deploy/migration/pre/01/image-policy.yaml
@@ -3,6 +3,9 @@ kind: ImagePolicy
 metadata:
   name: ffc-demo-claim-service-dbmigration-pre-01
   namespace: flux-config
+  labels:
+    backstage.io/kubernetes-id: ffc-demo-claim-service
+    backstage.io/kubernetes-team: ffc-demo
 spec:
   imageRepositoryRef:
     name: ffc-demo-claim-service-dbmigration

--- a/services/ffc/ffc-demo/ffc-demo-claim-service/pre-deploy/migration/snd/01/image-policy.yaml
+++ b/services/ffc/ffc-demo/ffc-demo-claim-service/pre-deploy/migration/snd/01/image-policy.yaml
@@ -3,6 +3,9 @@ kind: ImagePolicy
 metadata:
   name: ffc-demo-claim-service-dbmigration-snd-01
   namespace: flux-config
+  labels:
+    backstage.io/kubernetes-id: ffc-demo-claim-service
+    backstage.io/kubernetes-team: ffc-demo
 spec:
   imageRepositoryRef:
     name: ffc-demo-claim-service-dbmigration

--- a/services/ffc/ffc-demo/ffc-demo-claim-service/pre-deploy/migration/snd/02/image-policy.yaml
+++ b/services/ffc/ffc-demo/ffc-demo-claim-service/pre-deploy/migration/snd/02/image-policy.yaml
@@ -3,6 +3,9 @@ kind: ImagePolicy
 metadata:
   name: ffc-demo-claim-service-dbmigration-snd-02
   namespace: flux-config
+  labels:
+    backstage.io/kubernetes-id: ffc-demo-claim-service
+    backstage.io/kubernetes-team: ffc-demo
 spec:
   imageRepositoryRef:
     name: ffc-demo-claim-service-dbmigration

--- a/services/ffc/ffc-demo/ffc-demo-claim-service/pre-deploy/migration/snd/03/image-policy.yaml
+++ b/services/ffc/ffc-demo/ffc-demo-claim-service/pre-deploy/migration/snd/03/image-policy.yaml
@@ -3,6 +3,9 @@ kind: ImagePolicy
 metadata:
   name: ffc-demo-claim-service-dbmigration-snd-03
   namespace: flux-config
+  labels:
+    backstage.io/kubernetes-id: ffc-demo-claim-service
+    backstage.io/kubernetes-team: ffc-demo
 spec:
   imageRepositoryRef:
     name: ffc-demo-claim-service-dbmigration

--- a/services/ffc/ffc-demo/ffc-demo-claim-service/pre-deploy/migration/tst/01/image-policy.yaml
+++ b/services/ffc/ffc-demo/ffc-demo-claim-service/pre-deploy/migration/tst/01/image-policy.yaml
@@ -2,7 +2,10 @@ apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
 metadata:
   name: ffc-demo-claim-service-dbmigration-tst-01
-  namespace: flux-config
+  namespace: flux-config  
+  labels:
+    backstage.io/kubernetes-id: ffc-demo-claim-service
+    backstage.io/kubernetes-team: ffc-demo
 spec:
   imageRepositoryRef:
     name: ffc-demo-claim-service-dbmigration

--- a/services/ffc/ffc-demo/ffc-demo-claim-service/pre-deploy/post-migration-kustomize.yaml
+++ b/services/ffc/ffc-demo/ffc-demo-claim-service/pre-deploy/post-migration-kustomize.yaml
@@ -3,6 +3,9 @@ kind: Kustomization
 metadata:
   name: ffc-demo-claim-service-pre-deploy-post-migration
   namespace: flux-config
+  labels:
+    backstage.io/kubernetes-id: ffc-demo-claim-service
+    backstage.io/kubernetes-team: ffc-demo
 spec:
   dependsOn:
     - name: ffc-demo-claim-service-pre-deploy-migration

--- a/services/ffc/ffc-demo/ffc-demo-claim-service/pre-deploy/post-migration/base/post-migration-script.job.yaml
+++ b/services/ffc/ffc-demo/ffc-demo-claim-service/pre-deploy/post-migration/base/post-migration-script.job.yaml
@@ -5,11 +5,15 @@ metadata:
   namespace: ffc-demo
   labels:
     azure.workload.identity/use: "true"
+    backstage.io/kubernetes-id: ffc-demo-claim-service
+    backstage.io/kubernetes-team: ffc-demo  
 spec:
   template:
     metadata:
       labels:
         azure.workload.identity/use: "true"
+        backstage.io/kubernetes-id: ffc-demo-claim-service
+        backstage.io/kubernetes-team: ffc-demo
     spec:
       serviceAccountName: ${TEAM_NAMESPACE}
       restartPolicy: Never

--- a/services/ffc/ffc-demo/ffc-demo-claim-service/pre-deploy/pre-migration-kustomize.yaml
+++ b/services/ffc/ffc-demo/ffc-demo-claim-service/pre-deploy/pre-migration-kustomize.yaml
@@ -3,6 +3,9 @@ kind: Kustomization
 metadata:
   name: ffc-demo-claim-service-pre-deploy-pre-migration
   namespace: flux-config
+  labels:
+    backstage.io/kubernetes-id: ffc-demo-claim-service
+    backstage.io/kubernetes-team: ffc-demo  
 spec:
   sourceRef:
     kind: GitRepository

--- a/services/ffc/ffc-demo/ffc-demo-claim-service/pre-deploy/pre-migration/base/pre-migration-script.job.yaml
+++ b/services/ffc/ffc-demo/ffc-demo-claim-service/pre-deploy/pre-migration/base/pre-migration-script.job.yaml
@@ -5,6 +5,8 @@ metadata:
   namespace: flux-config
   labels:
     azure.workload.identity/use: "true"
+    backstage.io/kubernetes-id: ffc-demo-claim-service
+    backstage.io/kubernetes-team: ffc-demo
 spec:
   template:
     metadata:

--- a/services/ffc/ffc-demo/ffc-demo-payment-service/deploy-kustomize.yaml
+++ b/services/ffc/ffc-demo/ffc-demo-payment-service/deploy-kustomize.yaml
@@ -3,6 +3,9 @@ kind: Kustomization
 metadata:
   name: ffc-demo-payment-service-deploy
   namespace: flux-config
+  labels:
+    backstage.io/kubernetes-id: ffc-demo-payment-service
+    backstage.io/kubernetes-team: ffc-demo  
 spec:
   dependsOn:
     - name: ffc-demo-payment-service-pre-deploy

--- a/services/ffc/ffc-demo/ffc-demo-payment-service/deploy/base/helm-release.yaml
+++ b/services/ffc/ffc-demo/ffc-demo-payment-service/deploy/base/helm-release.yaml
@@ -3,6 +3,9 @@ kind: HelmRelease
 metadata:
   name: ffc-demo-payment-service
   namespace: flux-config
+  labels:
+    backstage.io/kubernetes-id: ffc-demo-payment-service
+    backstage.io/kubernetes-team: ffc-demo
 spec:
   releaseName: ffc-demo-payment-service
   chart:

--- a/services/ffc/ffc-demo/ffc-demo-payment-service/infra-kustomize.yaml
+++ b/services/ffc/ffc-demo/ffc-demo-payment-service/infra-kustomize.yaml
@@ -3,6 +3,9 @@ kind: Kustomization
 metadata:
   name: ffc-demo-payment-service-infra
   namespace: flux-config
+  labels:
+    backstage.io/kubernetes-id: ffc-demo-payment-service
+    backstage.io/kubernetes-team: ffc-demo  
 spec:
   sourceRef:
     kind: GitRepository

--- a/services/ffc/ffc-demo/ffc-demo-payment-service/infra/base/aso-helm-release.yaml
+++ b/services/ffc/ffc-demo/ffc-demo-payment-service/infra/base/aso-helm-release.yaml
@@ -3,6 +3,9 @@ kind: HelmRelease
 metadata:
   name: ffc-demo-payment-service-infra
   namespace: flux-config
+  labels:
+    backstage.io/kubernetes-id: ffc-demo-payment-service
+    backstage.io/kubernetes-team: ffc-demo
 spec:
   releaseName: ffc-demo-payment-service-infra
   chart:

--- a/services/ffc/ffc-demo/ffc-demo-payment-service/infra/base/image-repository.yaml
+++ b/services/ffc/ffc-demo/ffc-demo-payment-service/infra/base/image-repository.yaml
@@ -3,6 +3,9 @@ kind: ImageRepository
 metadata:
   name: ffc-demo-payment-service
   namespace: flux-config
+  labels:
+    backstage.io/kubernetes-id: ffc-demo-payment-service
+    backstage.io/kubernetes-team: ffc-demo
 spec:
   image: ${APPLICATION_ACR_NAME}.azurecr.io/image/ffc-demo-payment-service
   interval: 5m0s

--- a/services/ffc/ffc-demo/ffc-demo-payment-service/infra/dev/01/image-policy.yaml
+++ b/services/ffc/ffc-demo/ffc-demo-payment-service/infra/dev/01/image-policy.yaml
@@ -3,6 +3,9 @@ kind: ImagePolicy
 metadata:
   name: ffc-demo-payment-service-dev-01
   namespace: flux-config
+  labels:
+    backstage.io/kubernetes-id: ffc-demo-payment-service
+    backstage.io/kubernetes-team: ffc-demo
 spec:
   imageRepositoryRef:
     name: ffc-demo-payment-service

--- a/services/ffc/ffc-demo/ffc-demo-payment-service/infra/prd/01/image-policy.yaml
+++ b/services/ffc/ffc-demo/ffc-demo-payment-service/infra/prd/01/image-policy.yaml
@@ -3,6 +3,9 @@ kind: ImagePolicy
 metadata:
   name: ffc-demo-payment-service-prd-01
   namespace: flux-config
+  labels:
+    backstage.io/kubernetes-id: ffc-demo-payment-service
+    backstage.io/kubernetes-team: ffc-demo
 spec:
   imageRepositoryRef:
     name: ffc-demo-payment-service

--- a/services/ffc/ffc-demo/ffc-demo-payment-service/infra/pre/01/image-policy.yaml
+++ b/services/ffc/ffc-demo/ffc-demo-payment-service/infra/pre/01/image-policy.yaml
@@ -3,6 +3,9 @@ kind: ImagePolicy
 metadata:
   name: ffc-demo-payment-service-pre-01
   namespace: flux-config
+  labels:
+    backstage.io/kubernetes-id: ffc-demo-payment-service
+    backstage.io/kubernetes-team: ffc-demo
 spec:
   imageRepositoryRef:
     name: ffc-demo-payment-service

--- a/services/ffc/ffc-demo/ffc-demo-payment-service/infra/snd/01/image-policy.yaml
+++ b/services/ffc/ffc-demo/ffc-demo-payment-service/infra/snd/01/image-policy.yaml
@@ -3,6 +3,9 @@ kind: ImagePolicy
 metadata:
   name: ffc-demo-payment-service-snd-01
   namespace: flux-config
+  labels:
+    backstage.io/kubernetes-id: ffc-demo-payment-service
+    backstage.io/kubernetes-team: ffc-demo
 spec:
   imageRepositoryRef:
     name: ffc-demo-payment-service

--- a/services/ffc/ffc-demo/ffc-demo-payment-service/infra/snd/02/image-policy.yaml
+++ b/services/ffc/ffc-demo/ffc-demo-payment-service/infra/snd/02/image-policy.yaml
@@ -3,6 +3,9 @@ kind: ImagePolicy
 metadata:
   name: ffc-demo-payment-service-snd-02
   namespace: flux-config
+  labels:
+    backstage.io/kubernetes-id: ffc-demo-payment-service
+    backstage.io/kubernetes-team: ffc-demo
 spec:
   imageRepositoryRef:
     name: ffc-demo-payment-service

--- a/services/ffc/ffc-demo/ffc-demo-payment-service/infra/snd/03/image-policy.yaml
+++ b/services/ffc/ffc-demo/ffc-demo-payment-service/infra/snd/03/image-policy.yaml
@@ -3,6 +3,9 @@ kind: ImagePolicy
 metadata:
   name: ffc-demo-payment-service-snd-03
   namespace: flux-config
+  labels:
+    backstage.io/kubernetes-id: ffc-demo-payment-service
+    backstage.io/kubernetes-team: ffc-demo
 spec:
   imageRepositoryRef:
     name: ffc-demo-payment-service

--- a/services/ffc/ffc-demo/ffc-demo-payment-service/infra/tst/01/image-policy.yaml
+++ b/services/ffc/ffc-demo/ffc-demo-payment-service/infra/tst/01/image-policy.yaml
@@ -3,6 +3,9 @@ kind: ImagePolicy
 metadata:
   name: ffc-demo-payment-service-tst-01
   namespace: flux-config
+  labels:
+    backstage.io/kubernetes-id: ffc-demo-payment-service
+    backstage.io/kubernetes-team: ffc-demo
 spec:
   imageRepositoryRef:
     name: ffc-demo-payment-service

--- a/services/ffc/ffc-demo/ffc-demo-payment-service/infra/tst/02/image-policy.yaml
+++ b/services/ffc/ffc-demo/ffc-demo-payment-service/infra/tst/02/image-policy.yaml
@@ -3,6 +3,9 @@ kind: ImagePolicy
 metadata:
   name: ffc-demo-payment-service-tst-02
   namespace: flux-config
+  labels:
+    backstage.io/kubernetes-id: ffc-demo-payment-service
+    backstage.io/kubernetes-team: ffc-demo
 spec:
   imageRepositoryRef:
     name: ffc-demo-payment-service

--- a/services/ffc/ffc-demo/ffc-demo-payment-service/pre-deploy-kustomize.yaml
+++ b/services/ffc/ffc-demo/ffc-demo-payment-service/pre-deploy-kustomize.yaml
@@ -7,6 +7,9 @@ spec:
   dependsOn:
     - name: ffc-demo-payment-service-infra
       namespace: flux-config
+  labels:
+    backstage.io/kubernetes-id: ffc-demo-payment-service
+    backstage.io/kubernetes-team: ffc-demo      
   sourceRef:
     kind: GitRepository
     name: services-repository

--- a/services/ffc/ffc-demo/ffc-demo-payment-service/pre-deploy/migration-kustomize.yaml
+++ b/services/ffc/ffc-demo/ffc-demo-payment-service/pre-deploy/migration-kustomize.yaml
@@ -3,10 +3,14 @@ kind: Kustomization
 metadata:
   name: ffc-demo-payment-service-pre-deploy-migration
   namespace: flux-config
+  labels:
+    backstage.io/kubernetes-id: ffc-demo-payment-service
+    backstage.io/kubernetes-team: ffc-demo  
 spec:
   dependsOn:
     - name: ffc-demo-payment-service-pre-deploy-pre-migration
       namespace: flux-config
+      
   sourceRef:
     kind: GitRepository
     name: services-repository

--- a/services/ffc/ffc-demo/ffc-demo-payment-service/pre-deploy/migration/base/image-repository-dbmigration.yaml
+++ b/services/ffc/ffc-demo/ffc-demo-payment-service/pre-deploy/migration/base/image-repository-dbmigration.yaml
@@ -4,6 +4,9 @@ kind: ImageRepository
 metadata:
   name: ffc-demo-payment-service-dbmigration
   namespace: flux-config
+  labels:
+    backstage.io/kubernetes-id: ffc-demo-payment-service
+    backstage.io/kubernetes-team: ffc-demo
 spec:
   image: ${APPLICATION_ACR_NAME}.azurecr.io/image/ffc-demo-payment-service-dbmigration
   interval: 5m0s

--- a/services/ffc/ffc-demo/ffc-demo-payment-service/pre-deploy/migration/base/migration.job.yaml
+++ b/services/ffc/ffc-demo/ffc-demo-payment-service/pre-deploy/migration/base/migration.job.yaml
@@ -5,6 +5,8 @@ metadata:
   namespace: ffc-demo
   labels:
     azure.workload.identity/use: "true"
+    backstage.io/kubernetes-id: ffc-demo-payment-service
+    backstage.io/kubernetes-team: ffc-demo
 spec:
   template:
     metadata:

--- a/services/ffc/ffc-demo/ffc-demo-payment-service/pre-deploy/migration/base/migration.job.yaml
+++ b/services/ffc/ffc-demo/ffc-demo-payment-service/pre-deploy/migration/base/migration.job.yaml
@@ -12,6 +12,8 @@ spec:
     metadata:
       labels:
         azure.workload.identity/use: "true"
+        backstage.io/kubernetes-id: ffc-demo-payment-service
+        backstage.io/kubernetes-team: ffc-demo        
     spec:
       serviceAccountName: ${TEAM_NAMESPACE}
       restartPolicy: Never

--- a/services/ffc/ffc-demo/ffc-demo-payment-service/pre-deploy/migration/dev/01/image-policy.yaml
+++ b/services/ffc/ffc-demo/ffc-demo-payment-service/pre-deploy/migration/dev/01/image-policy.yaml
@@ -3,6 +3,9 @@ kind: ImagePolicy
 metadata:
   name: ffc-demo-payment-service-dbmigration-dev-01
   namespace: flux-config
+  labels:
+    backstage.io/kubernetes-id: ffc-demo-payment-service
+    backstage.io/kubernetes-team: ffc-demo
 spec:
   imageRepositoryRef:
     name: ffc-demo-payment-service-dbmigration

--- a/services/ffc/ffc-demo/ffc-demo-payment-service/pre-deploy/migration/prd/01/image-policy.yaml
+++ b/services/ffc/ffc-demo/ffc-demo-payment-service/pre-deploy/migration/prd/01/image-policy.yaml
@@ -3,6 +3,9 @@ kind: ImagePolicy
 metadata:
   name: ffc-demo-payment-service-dbmigration-prd-01
   namespace: flux-config
+  labels:
+    backstage.io/kubernetes-id: ffc-demo-payment-service
+    backstage.io/kubernetes-team: ffc-demo
 spec:
   imageRepositoryRef:
     name: ffc-demo-payment-service-dbmigration

--- a/services/ffc/ffc-demo/ffc-demo-payment-service/pre-deploy/migration/pre/01/image-policy.yaml
+++ b/services/ffc/ffc-demo/ffc-demo-payment-service/pre-deploy/migration/pre/01/image-policy.yaml
@@ -3,6 +3,9 @@ kind: ImagePolicy
 metadata:
   name: ffc-demo-payment-service-dbmigration-pre-01
   namespace: flux-config
+  labels:
+    backstage.io/kubernetes-id: ffc-demo-payment-service
+    backstage.io/kubernetes-team: ffc-demo
 spec:
   imageRepositoryRef:
     name: ffc-demo-payment-service-dbmigration

--- a/services/ffc/ffc-demo/ffc-demo-payment-service/pre-deploy/migration/snd/01/image-policy.yaml
+++ b/services/ffc/ffc-demo/ffc-demo-payment-service/pre-deploy/migration/snd/01/image-policy.yaml
@@ -3,6 +3,9 @@ kind: ImagePolicy
 metadata:
   name: ffc-demo-payment-service-dbmigration-snd-01
   namespace: flux-config
+  labels:
+    backstage.io/kubernetes-id: ffc-demo-payment-service
+    backstage.io/kubernetes-team: ffc-demo
 spec:
   imageRepositoryRef:
     name: ffc-demo-payment-service-dbmigration

--- a/services/ffc/ffc-demo/ffc-demo-payment-service/pre-deploy/migration/snd/02/image-policy.yaml
+++ b/services/ffc/ffc-demo/ffc-demo-payment-service/pre-deploy/migration/snd/02/image-policy.yaml
@@ -3,6 +3,9 @@ kind: ImagePolicy
 metadata:
   name: ffc-demo-payment-service-dbmigration-snd-02
   namespace: flux-config
+  labels:
+    backstage.io/kubernetes-id: ffc-demo-payment-service
+    backstage.io/kubernetes-team: ffc-demo
 spec:
   imageRepositoryRef:
     name: ffc-demo-payment-service-dbmigration

--- a/services/ffc/ffc-demo/ffc-demo-payment-service/pre-deploy/migration/snd/03/image-policy.yaml
+++ b/services/ffc/ffc-demo/ffc-demo-payment-service/pre-deploy/migration/snd/03/image-policy.yaml
@@ -3,6 +3,9 @@ kind: ImagePolicy
 metadata:
   name: ffc-demo-payment-service-dbmigration-snd-03
   namespace: flux-config
+  labels:
+    backstage.io/kubernetes-id: ffc-demo-payment-service
+    backstage.io/kubernetes-team: ffc-demo
 spec:
   imageRepositoryRef:
     name: ffc-demo-payment-service-dbmigration

--- a/services/ffc/ffc-demo/ffc-demo-payment-service/pre-deploy/migration/tst/01/image-policy.yaml
+++ b/services/ffc/ffc-demo/ffc-demo-payment-service/pre-deploy/migration/tst/01/image-policy.yaml
@@ -3,6 +3,9 @@ kind: ImagePolicy
 metadata:
   name: ffc-demo-payment-service-dbmigration-tst-01
   namespace: flux-config
+  labels:
+    backstage.io/kubernetes-id: ffc-demo-payment-service
+    backstage.io/kubernetes-team: ffc-demo
 spec:
   imageRepositoryRef:
     name: ffc-demo-payment-service-dbmigration

--- a/services/ffc/ffc-demo/ffc-demo-payment-service/pre-deploy/migration/tst/02/image-policy.yaml
+++ b/services/ffc/ffc-demo/ffc-demo-payment-service/pre-deploy/migration/tst/02/image-policy.yaml
@@ -3,6 +3,9 @@ kind: ImagePolicy
 metadata:
   name: ffc-demo-payment-service-dbmigration-tst-02
   namespace: flux-config
+  labels:
+    backstage.io/kubernetes-id: ffc-demo-payment-service
+    backstage.io/kubernetes-team: ffc-demo
 spec:
   imageRepositoryRef:
     name: ffc-demo-payment-service-dbmigration

--- a/services/ffc/ffc-demo/ffc-demo-payment-service/pre-deploy/post-migration-kustomize.yaml
+++ b/services/ffc/ffc-demo/ffc-demo-payment-service/pre-deploy/post-migration-kustomize.yaml
@@ -3,6 +3,9 @@ kind: Kustomization
 metadata:
   name: ffc-demo-payment-service-pre-deploy-post-migration
   namespace: flux-config
+  labels:
+    backstage.io/kubernetes-id: ffc-demo-payment-service
+    backstage.io/kubernetes-team: ffc-demo  
 spec:
   dependsOn:
     - name: ffc-demo-payment-service-pre-deploy-migration

--- a/services/ffc/ffc-demo/ffc-demo-payment-service/pre-deploy/post-migration/base/post-migration-script.job.yaml
+++ b/services/ffc/ffc-demo/ffc-demo-payment-service/pre-deploy/post-migration/base/post-migration-script.job.yaml
@@ -5,6 +5,8 @@ metadata:
   namespace: ffc-demo
   labels:
     azure.workload.identity/use: "true"
+    backstage.io/kubernetes-id: ffc-demo-payment-service
+    backstage.io/kubernetes-team: ffc-demo
 spec:
   template:
     metadata:

--- a/services/ffc/ffc-demo/ffc-demo-payment-service/pre-deploy/pre-migration-kustomize.yaml
+++ b/services/ffc/ffc-demo/ffc-demo-payment-service/pre-deploy/pre-migration-kustomize.yaml
@@ -3,6 +3,9 @@ kind: Kustomization
 metadata:
   name: ffc-demo-payment-service-pre-deploy-pre-migration
   namespace: flux-config
+  labels:
+    backstage.io/kubernetes-id: ffc-demo-payment-service
+    backstage.io/kubernetes-team: ffc-demo  
 spec:
   sourceRef:
     kind: GitRepository

--- a/services/ffc/ffc-demo/ffc-demo-payment-service/pre-deploy/pre-migration/base/pre-migration-script.job.yaml
+++ b/services/ffc/ffc-demo/ffc-demo-payment-service/pre-deploy/pre-migration/base/pre-migration-script.job.yaml
@@ -5,11 +5,15 @@ metadata:
   namespace: flux-config
   labels:
     azure.workload.identity/use: "true"
+    backstage.io/kubernetes-id: ffc-demo-payment-service
+    backstage.io/kubernetes-team: ffc-demo
 spec:
   template:
     metadata:
       labels:
         azure.workload.identity/use: "true"
+        backstage.io/kubernetes-id: ffc-demo-payment-service
+        backstage.io/kubernetes-team: ffc-demo
     spec:
       serviceAccountName: ${PLATFORM_DB_ADMIN}
       restartPolicy: Never

--- a/services/ffc/ffc-demo/ffc-demo-payment-web/deploy-kustomize.yaml
+++ b/services/ffc/ffc-demo/ffc-demo-payment-web/deploy-kustomize.yaml
@@ -3,6 +3,9 @@ kind: Kustomization
 metadata:
   name: ffc-demo-payment-web-deploy
   namespace: flux-config
+  labels:
+    backstage.io/kubernetes-id: ffc-demo-payment-web
+    backstage.io/kubernetes-team: ffc-demo
 spec:
   dependsOn:
     - name: ffc-demo-payment-web-infra

--- a/services/ffc/ffc-demo/ffc-demo-payment-web/deploy/base/helm-release.yaml
+++ b/services/ffc/ffc-demo/ffc-demo-payment-web/deploy/base/helm-release.yaml
@@ -3,6 +3,9 @@ kind: HelmRelease
 metadata:
   name: ffc-demo-payment-web
   namespace: flux-config
+  labels:
+    backstage.io/kubernetes-id: ffc-demo-payment-web
+    backstage.io/kubernetes-team: ffc-demo  
 spec:
   releaseName: ffc-demo-payment-web
   chart:

--- a/services/ffc/ffc-demo/ffc-demo-payment-web/infra-kustomize.yaml
+++ b/services/ffc/ffc-demo/ffc-demo-payment-web/infra-kustomize.yaml
@@ -3,6 +3,9 @@ kind: Kustomization
 metadata:
   name: ffc-demo-payment-web-infra
   namespace: flux-config
+  labels:
+    backstage.io/kubernetes-id: ffc-demo-payment-web
+    backstage.io/kubernetes-team: ffc-demo
 spec:
   sourceRef:
     kind: GitRepository

--- a/services/ffc/ffc-demo/ffc-demo-payment-web/infra/base/aso-helm-release.yaml
+++ b/services/ffc/ffc-demo/ffc-demo-payment-web/infra/base/aso-helm-release.yaml
@@ -3,6 +3,9 @@ kind: HelmRelease
 metadata:
   name: ffc-demo-payment-web-infra
   namespace: flux-config
+  labels:
+    backstage.io/kubernetes-id: ffc-demo-payment-web
+    backstage.io/kubernetes-team: ffc-demo  
 spec:
   releaseName: ffc-demo-payment-web-infra
   chart:

--- a/services/ffc/ffc-demo/ffc-demo-payment-web/infra/base/image-repository.yaml
+++ b/services/ffc/ffc-demo/ffc-demo-payment-web/infra/base/image-repository.yaml
@@ -3,6 +3,9 @@ kind: ImageRepository
 metadata:
   name: ffc-demo-payment-web
   namespace: flux-config
+  labels:
+    backstage.io/kubernetes-id: ffc-demo-payment-web
+    backstage.io/kubernetes-team: ffc-demo  
 spec:
   image: ${APPLICATION_ACR_NAME}.azurecr.io/image/ffc-demo-payment-web
   interval: 5m0s

--- a/services/ffc/ffc-demo/ffc-demo-payment-web/infra/dev/01/image-policy.yaml
+++ b/services/ffc/ffc-demo/ffc-demo-payment-web/infra/dev/01/image-policy.yaml
@@ -3,6 +3,9 @@ kind: ImagePolicy
 metadata:
   name: ffc-demo-payment-web-dev-01
   namespace: flux-config
+  labels:
+    backstage.io/kubernetes-id: ffc-demo-payment-web
+    backstage.io/kubernetes-team: ffc-demo  
 spec:
   imageRepositoryRef:
     name: ffc-demo-payment-web

--- a/services/ffc/ffc-demo/ffc-demo-payment-web/infra/prd/01/image-policy.yaml
+++ b/services/ffc/ffc-demo/ffc-demo-payment-web/infra/prd/01/image-policy.yaml
@@ -3,6 +3,9 @@ kind: ImagePolicy
 metadata:
   name: ffc-demo-payment-web-prd-01
   namespace: flux-config
+  labels:
+    backstage.io/kubernetes-id: ffc-demo-payment-web
+    backstage.io/kubernetes-team: ffc-demo  
 spec:
   imageRepositoryRef:
     name: ffc-demo-payment-web

--- a/services/ffc/ffc-demo/ffc-demo-payment-web/infra/pre/01/image-policy.yaml
+++ b/services/ffc/ffc-demo/ffc-demo-payment-web/infra/pre/01/image-policy.yaml
@@ -3,6 +3,9 @@ kind: ImagePolicy
 metadata:
   name: ffc-demo-payment-web-pre-01
   namespace: flux-config
+  labels:
+    backstage.io/kubernetes-id: ffc-demo-payment-web
+    backstage.io/kubernetes-team: ffc-demo  
 spec:
   imageRepositoryRef:
     name: ffc-demo-payment-web

--- a/services/ffc/ffc-demo/ffc-demo-payment-web/infra/snd/01/image-policy.yaml
+++ b/services/ffc/ffc-demo/ffc-demo-payment-web/infra/snd/01/image-policy.yaml
@@ -3,6 +3,9 @@ kind: ImagePolicy
 metadata:
   name: ffc-demo-payment-web-snd-01
   namespace: flux-config
+  labels:
+    backstage.io/kubernetes-id: ffc-demo-payment-web
+    backstage.io/kubernetes-team: ffc-demo  
 spec:
   imageRepositoryRef:
     name: ffc-demo-payment-web

--- a/services/ffc/ffc-demo/ffc-demo-payment-web/infra/snd/02/image-policy.yaml
+++ b/services/ffc/ffc-demo/ffc-demo-payment-web/infra/snd/02/image-policy.yaml
@@ -3,6 +3,9 @@ kind: ImagePolicy
 metadata:
   name: ffc-demo-payment-web-snd-02
   namespace: flux-config
+  labels:
+    backstage.io/kubernetes-id: ffc-demo-payment-web
+    backstage.io/kubernetes-team: ffc-demo  
 spec:
   imageRepositoryRef:
     name: ffc-demo-payment-web

--- a/services/ffc/ffc-demo/ffc-demo-payment-web/infra/snd/03/image-policy.yaml
+++ b/services/ffc/ffc-demo/ffc-demo-payment-web/infra/snd/03/image-policy.yaml
@@ -3,6 +3,9 @@ kind: ImagePolicy
 metadata:
   name: ffc-demo-payment-web-snd-03
   namespace: flux-config
+  labels:
+    backstage.io/kubernetes-id: ffc-demo-payment-web
+    backstage.io/kubernetes-team: ffc-demo  
 spec:
   imageRepositoryRef:
     name: ffc-demo-payment-web

--- a/services/ffc/ffc-demo/ffc-demo-payment-web/infra/tst/01/image-policy.yaml
+++ b/services/ffc/ffc-demo/ffc-demo-payment-web/infra/tst/01/image-policy.yaml
@@ -3,6 +3,9 @@ kind: ImagePolicy
 metadata:
   name: ffc-demo-payment-web-tst-01
   namespace: flux-config
+  labels:
+    backstage.io/kubernetes-id: ffc-demo-payment-web
+    backstage.io/kubernetes-team: ffc-demo  
 spec:
   imageRepositoryRef:
     name: ffc-demo-payment-web

--- a/services/ffc/ffc-demo/ffc-demo-payment-web/infra/tst/02/image-policy.yaml
+++ b/services/ffc/ffc-demo/ffc-demo-payment-web/infra/tst/02/image-policy.yaml
@@ -3,6 +3,9 @@ kind: ImagePolicy
 metadata:
   name: ffc-demo-payment-web-tst-02
   namespace: flux-config
+  labels:
+    backstage.io/kubernetes-id: ffc-demo-payment-web
+    backstage.io/kubernetes-team: ffc-demo  
 spec:
   imageRepositoryRef:
     name: ffc-demo-payment-web

--- a/services/ffc/ffc-demo/ffc-demo-web/deploy-kustomize.yaml
+++ b/services/ffc/ffc-demo/ffc-demo-web/deploy-kustomize.yaml
@@ -3,6 +3,9 @@ kind: Kustomization
 metadata:
   name: ffc-demo-web-deploy
   namespace: flux-config
+  labels:
+    backstage.io/kubernetes-id: ffc-demo-web
+    backstage.io/kubernetes-team: ffc-demo
 spec:
   dependsOn:
     - name: ffc-demo-web-infra

--- a/services/ffc/ffc-demo/ffc-demo-web/deploy/base/helm-release.yaml
+++ b/services/ffc/ffc-demo/ffc-demo-web/deploy/base/helm-release.yaml
@@ -3,6 +3,9 @@ kind: HelmRelease
 metadata:
   name: ffc-demo-web
   namespace: flux-config
+  labels:
+    backstage.io/kubernetes-id: ffc-demo-web
+    backstage.io/kubernetes-team: ffc-demo
 spec:
   releaseName: ffc-demo-web
   chart:

--- a/services/ffc/ffc-demo/ffc-demo-web/infra-kustomize.yaml
+++ b/services/ffc/ffc-demo/ffc-demo-web/infra-kustomize.yaml
@@ -3,6 +3,9 @@ kind: Kustomization
 metadata:
   name: ffc-demo-web-infra
   namespace: flux-config
+  labels:
+    backstage.io/kubernetes-id: ffc-demo-web
+    backstage.io/kubernetes-team: ffc-demo  
 spec:
   sourceRef:
     kind: GitRepository

--- a/services/ffc/ffc-ffd/base/helm-repository.yaml
+++ b/services/ffc/ffc-ffd/base/helm-repository.yaml
@@ -3,6 +3,8 @@ kind: HelmRepository
 metadata:
   name: ffc-ffd-helm-repo
   namespace: flux-config
+  labels:
+    backstage.io/kubernetes-team: ffc-ffd  
 spec:
   type: oci
   interval: 5m

--- a/services/ffc/ffc-ffd/base/patch/kustomize.yaml
+++ b/services/ffc/ffc-ffd/base/patch/kustomize.yaml
@@ -3,6 +3,8 @@ kind: Kustomization
 metadata:
   name: ffc-ffd-base
   namespace: flux-config
+  labels:
+    backstage.io/kubernetes-team: ffc-ffd  
 spec:
   sourceRef:
     kind: GitRepository

--- a/services/ffc/ffc-ffd/ffc-ffd-backend-poc/deploy-kustomize.yaml
+++ b/services/ffc/ffc-ffd/ffc-ffd-backend-poc/deploy-kustomize.yaml
@@ -3,6 +3,9 @@ kind: Kustomization
 metadata:
   name: ffc-ffd-backend-poc-deploy
   namespace: flux-config
+  labels:
+    backstage.io/kubernetes-id: ffc-ffd-backend-poc
+    backstage.io/kubernetes-team: ffc-demo  
 spec:
   dependsOn:
     - name: ffc-ffd-backend-poc-pre-deploy

--- a/services/ffc/ffc-ffd/ffc-ffd-backend-poc/deploy/base/helm-release.yaml
+++ b/services/ffc/ffc-ffd/ffc-ffd-backend-poc/deploy/base/helm-release.yaml
@@ -3,6 +3,9 @@ kind: HelmRelease
 metadata:
   name: ffc-ffd-backend-poc
   namespace: flux-config
+  labels:
+    backstage.io/kubernetes-id: ffc-ffd-backend-poc
+    backstage.io/kubernetes-team: ffc-demo
 spec:
   releaseName: ffc-ffd-backend-poc
   chart:

--- a/services/ffc/ffc-ffd/ffc-ffd-backend-poc/infra-kustomize.yaml
+++ b/services/ffc/ffc-ffd/ffc-ffd-backend-poc/infra-kustomize.yaml
@@ -3,6 +3,9 @@ kind: Kustomization
 metadata:
   name: ffc-ffd-backend-poc-infra
   namespace: flux-config
+  labels:
+    backstage.io/kubernetes-id: ffc-ffd-backend-poc
+    backstage.io/kubernetes-team: ffc-demo  
 spec:
   sourceRef:
     kind: GitRepository

--- a/services/ffc/ffc-ffd/ffc-ffd-backend-poc/infra/base/aso-helm-release.yaml
+++ b/services/ffc/ffc-ffd/ffc-ffd-backend-poc/infra/base/aso-helm-release.yaml
@@ -3,6 +3,9 @@ kind: HelmRelease
 metadata:
   name: ffc-ffd-backend-poc-infra
   namespace: flux-config
+  labels:
+    backstage.io/kubernetes-id: ffc-ffd-backend-poc
+    backstage.io/kubernetes-team: ffc-demo  
 spec:
   releaseName: ffc-ffd-backend-poc-infra
   chart:

--- a/services/ffc/ffc-ffd/ffc-ffd-backend-poc/infra/base/image-repository.yaml
+++ b/services/ffc/ffc-ffd/ffc-ffd-backend-poc/infra/base/image-repository.yaml
@@ -3,6 +3,9 @@ kind: ImageRepository
 metadata:
   name: ffc-ffd-backend-poc
   namespace: flux-config
+  labels:
+    backstage.io/kubernetes-id: ffc-ffd-backend-poc
+    backstage.io/kubernetes-team: ffc-demo  
 spec:
   image: ${APPLICATION_ACR_NAME}.azurecr.io/image/ffc-ffd-backend-poc
   interval: 5m0s

--- a/services/ffc/ffc-ffd/ffc-ffd-backend-poc/infra/snd/01/image-policy.yaml
+++ b/services/ffc/ffc-ffd/ffc-ffd-backend-poc/infra/snd/01/image-policy.yaml
@@ -3,6 +3,9 @@ kind: ImagePolicy
 metadata:
   name: ffc-ffd-backend-poc-snd-01
   namespace: flux-config
+  labels:
+    backstage.io/kubernetes-id: ffc-ffd-backend-poc
+    backstage.io/kubernetes-team: ffc-demo  
 spec:
   imageRepositoryRef:
     name: ffc-ffd-backend-poc

--- a/services/ffc/ffc-ffd/ffc-ffd-backend-poc/infra/snd/02/image-policy.yaml
+++ b/services/ffc/ffc-ffd/ffc-ffd-backend-poc/infra/snd/02/image-policy.yaml
@@ -3,6 +3,9 @@ kind: ImagePolicy
 metadata:
   name: ffc-ffd-backend-poc-snd-02
   namespace: flux-config
+  labels:
+    backstage.io/kubernetes-id: ffc-ffd-backend-poc
+    backstage.io/kubernetes-team: ffc-demo  
 spec:
   imageRepositoryRef:
     name: ffc-ffd-backend-poc

--- a/services/ffc/ffc-ffd/ffc-ffd-backend-poc/infra/snd/03/image-policy.yaml
+++ b/services/ffc/ffc-ffd/ffc-ffd-backend-poc/infra/snd/03/image-policy.yaml
@@ -3,6 +3,9 @@ kind: ImagePolicy
 metadata:
   name: ffc-ffd-backend-poc-snd-03
   namespace: flux-config
+  labels:
+    backstage.io/kubernetes-id: ffc-ffd-backend-poc
+    backstage.io/kubernetes-team: ffc-demo  
 spec:
   imageRepositoryRef:
     name: ffc-ffd-backend-poc

--- a/services/ffc/ffc-ffd/ffc-ffd-backend-poc/pre-deploy-kustomize.yaml
+++ b/services/ffc/ffc-ffd/ffc-ffd-backend-poc/pre-deploy-kustomize.yaml
@@ -3,6 +3,9 @@ kind: Kustomization
 metadata:
   name: ffc-ffd-backend-poc-pre-deploy
   namespace: flux-config
+  labels:
+    backstage.io/kubernetes-id: ffc-ffd-backend-poc
+    backstage.io/kubernetes-team: ffc-demo  
 spec:
   dependsOn:
     - name: ffc-ffd-backend-poc-infra

--- a/services/ffc/ffc-ffd/ffc-ffd-backend-poc/pre-deploy/migration-kustomize.yaml
+++ b/services/ffc/ffc-ffd/ffc-ffd-backend-poc/pre-deploy/migration-kustomize.yaml
@@ -3,6 +3,9 @@ kind: Kustomization
 metadata:
   name: ffc-ffd-backend-poc-pre-deploy-migration
   namespace: flux-config
+  labels:
+    backstage.io/kubernetes-id: ffc-ffd-backend-poc
+    backstage.io/kubernetes-team: ffc-demo
 spec:
   dependsOn:
     - name: ffc-ffd-backend-poc-pre-deploy-pre-migration

--- a/services/ffc/ffc-ffd/ffc-ffd-backend-poc/pre-deploy/migration/base/image-repository-dbmigration.yaml
+++ b/services/ffc/ffc-ffd/ffc-ffd-backend-poc/pre-deploy/migration/base/image-repository-dbmigration.yaml
@@ -4,6 +4,9 @@ kind: ImageRepository
 metadata:
   name: ffc-ffd-backend-poc-dbmigration
   namespace: flux-config
+  labels:
+    backstage.io/kubernetes-id: ffc-ffd-backend-poc
+    backstage.io/kubernetes-team: ffc-demo  
 spec:
   image: ${APPLICATION_ACR_NAME}.azurecr.io/image/ffc-ffd-backend-poc-dbmigration
   interval: 5m0s

--- a/services/ffc/ffc-ffd/ffc-ffd-backend-poc/pre-deploy/migration/base/migration.job.yaml
+++ b/services/ffc/ffc-ffd/ffc-ffd-backend-poc/pre-deploy/migration/base/migration.job.yaml
@@ -5,6 +5,8 @@ metadata:
   namespace: ffc-ffd
   labels:
     azure.workload.identity/use: "true"
+    backstage.io/kubernetes-id: ffc-ffd-backend-poc
+    backstage.io/kubernetes-team: ffc-demo
 spec:
   template:
     metadata:

--- a/services/ffc/ffc-ffd/ffc-ffd-backend-poc/pre-deploy/migration/base/migration.job.yaml
+++ b/services/ffc/ffc-ffd/ffc-ffd-backend-poc/pre-deploy/migration/base/migration.job.yaml
@@ -12,6 +12,8 @@ spec:
     metadata:
       labels:
         azure.workload.identity/use: "true"
+        backstage.io/kubernetes-id: ffc-ffd-backend-poc
+        backstage.io/kubernetes-team: ffc-demo        
     spec:
       serviceAccountName: ${TEAM_NAMESPACE}
       restartPolicy: Never

--- a/services/ffc/ffc-ffd/ffc-ffd-backend-poc/pre-deploy/migration/snd/01/image-policy.yaml
+++ b/services/ffc/ffc-ffd/ffc-ffd-backend-poc/pre-deploy/migration/snd/01/image-policy.yaml
@@ -3,6 +3,9 @@ kind: ImagePolicy
 metadata:
   name: ffc-ffd-backend-poc-dbmigration-snd-01
   namespace: flux-config
+  labels:
+    backstage.io/kubernetes-id: ffc-ffd-backend-poc
+    backstage.io/kubernetes-team: ffc-demo  
 spec:
   imageRepositoryRef:
     name: ffc-ffd-backend-poc-dbmigration

--- a/services/ffc/ffc-ffd/ffc-ffd-backend-poc/pre-deploy/migration/snd/02/image-policy.yaml
+++ b/services/ffc/ffc-ffd/ffc-ffd-backend-poc/pre-deploy/migration/snd/02/image-policy.yaml
@@ -3,6 +3,9 @@ kind: ImagePolicy
 metadata:
   name: ffc-ffd-backend-poc-dbmigration-snd-02
   namespace: flux-config
+  labels:
+    backstage.io/kubernetes-id: ffc-ffd-backend-poc
+    backstage.io/kubernetes-team: ffc-demo  
 spec:
   imageRepositoryRef:
     name: ffc-ffd-backend-poc-dbmigration

--- a/services/ffc/ffc-ffd/ffc-ffd-backend-poc/pre-deploy/migration/snd/03/image-policy.yaml
+++ b/services/ffc/ffc-ffd/ffc-ffd-backend-poc/pre-deploy/migration/snd/03/image-policy.yaml
@@ -3,6 +3,9 @@ kind: ImagePolicy
 metadata:
   name: ffc-ffd-backend-poc-dbmigration-snd-03
   namespace: flux-config
+  labels:
+    backstage.io/kubernetes-id: ffc-ffd-backend-poc
+    backstage.io/kubernetes-team: ffc-demo  
 spec:
   imageRepositoryRef:
     name: ffc-ffd-backend-poc-dbmigration

--- a/services/ffc/ffc-ffd/ffc-ffd-backend-poc/pre-deploy/post-migration-kustomize.yaml
+++ b/services/ffc/ffc-ffd/ffc-ffd-backend-poc/pre-deploy/post-migration-kustomize.yaml
@@ -3,6 +3,9 @@ kind: Kustomization
 metadata:
   name: ffc-ffd-backend-poc-pre-deploy-post-migration
   namespace: flux-config
+  labels:
+    backstage.io/kubernetes-id: ffc-ffd-backend-poc
+    backstage.io/kubernetes-team: ffc-demo
 spec:
   dependsOn:
     - name: ffc-ffd-backend-poc-pre-deploy-migration

--- a/services/ffc/ffc-ffd/ffc-ffd-backend-poc/pre-deploy/post-migration/base/post-migration-script.job.yaml
+++ b/services/ffc/ffc-ffd/ffc-ffd-backend-poc/pre-deploy/post-migration/base/post-migration-script.job.yaml
@@ -5,11 +5,15 @@ metadata:
   namespace: ffc-ffd
   labels:
     azure.workload.identity/use: "true"
+    backstage.io/kubernetes-id: ffc-ffd-backend-poc
+    backstage.io/kubernetes-team: ffc-demo    
 spec:
   template:
     metadata:
       labels:
         azure.workload.identity/use: "true"
+        backstage.io/kubernetes-id: ffc-ffd-backend-poc
+        backstage.io/kubernetes-team: ffc-demo    
     spec:
       serviceAccountName: ${TEAM_NAMESPACE}
       restartPolicy: Never

--- a/services/ffc/ffc-ffd/ffc-ffd-backend-poc/pre-deploy/pre-migration-kustomize.yaml
+++ b/services/ffc/ffc-ffd/ffc-ffd-backend-poc/pre-deploy/pre-migration-kustomize.yaml
@@ -3,6 +3,9 @@ kind: Kustomization
 metadata:
   name: ffc-ffd-backend-poc-pre-deploy-pre-migration
   namespace: flux-config
+  labels:
+    backstage.io/kubernetes-id: ffc-ffd-backend-poc
+    backstage.io/kubernetes-team: ffc-demo  
 spec:
   sourceRef:
     kind: GitRepository

--- a/services/ffc/ffc-ffd/ffc-ffd-backend-poc/pre-deploy/pre-migration/base/pre-migration-script.job.yaml
+++ b/services/ffc/ffc-ffd/ffc-ffd-backend-poc/pre-deploy/pre-migration/base/pre-migration-script.job.yaml
@@ -5,11 +5,15 @@ metadata:
   namespace: flux-config
   labels:
     azure.workload.identity/use: "true"
+    backstage.io/kubernetes-id: ffc-ffd-backend-poc
+    backstage.io/kubernetes-team: ffc-demo
 spec:
   template:
     metadata:
       labels:
         azure.workload.identity/use: "true"
+        backstage.io/kubernetes-id: ffc-ffd-backend-poc
+        backstage.io/kubernetes-team: ffc-demo
     spec:
       serviceAccountName: ${PLATFORM_DB_ADMIN}
       restartPolicy: Never

--- a/services/ffc/ffc-ffd/ffc-ffd-frontend-poc/deploy-kustomize.yaml
+++ b/services/ffc/ffc-ffd/ffc-ffd-frontend-poc/deploy-kustomize.yaml
@@ -3,6 +3,9 @@ kind: Kustomization
 metadata:
   name: ffc-ffd-frontend-poc-deploy
   namespace: flux-config
+  labels:
+    backstage.io/kubernetes-id: ffc-ffd-frontend-poc
+    backstage.io/kubernetes-team: ffc-demo  
 spec:
   dependsOn:
     - name: ffc-ffd-frontend-poc-infra

--- a/services/ffc/ffc-ffd/ffc-ffd-frontend-poc/deploy/base/helm-release.yaml
+++ b/services/ffc/ffc-ffd/ffc-ffd-frontend-poc/deploy/base/helm-release.yaml
@@ -3,6 +3,9 @@ kind: HelmRelease
 metadata:
   name: ffc-ffd-frontend-poc
   namespace: flux-config
+  labels:
+    backstage.io/kubernetes-id: ffc-ffd-frontend-poc
+    backstage.io/kubernetes-team: ffc-demo
 spec:
   releaseName: ffc-ffd-frontend-poc
   chart:

--- a/services/ffc/ffc-ffd/ffc-ffd-frontend-poc/infra-kustomize.yaml
+++ b/services/ffc/ffc-ffd/ffc-ffd-frontend-poc/infra-kustomize.yaml
@@ -3,6 +3,9 @@ kind: Kustomization
 metadata:
   name: ffc-ffd-frontend-poc-infra
   namespace: flux-config
+  labels:
+    backstage.io/kubernetes-id: ffc-ffd-frontend-poc
+    backstage.io/kubernetes-team: ffc-demo  
 spec:
   sourceRef:
     kind: GitRepository

--- a/services/ffc/ffc-ffd/ffc-ffd-frontend-poc/infra/base/aso-helm-release.yaml
+++ b/services/ffc/ffc-ffd/ffc-ffd-frontend-poc/infra/base/aso-helm-release.yaml
@@ -3,6 +3,9 @@ kind: HelmRelease
 metadata:
   name: ffc-ffd-frontend-poc-infra
   namespace: flux-config
+  labels:
+    backstage.io/kubernetes-id: ffc-ffd-frontend-poc
+    backstage.io/kubernetes-team: ffc-demo  
 spec:
   releaseName: ffc-ffd-frontend-poc-infra
   chart:

--- a/services/ffc/ffc-ffd/ffc-ffd-frontend-poc/infra/base/image-repository.yaml
+++ b/services/ffc/ffc-ffd/ffc-ffd-frontend-poc/infra/base/image-repository.yaml
@@ -3,6 +3,9 @@ kind: ImageRepository
 metadata:
   name: ffc-ffd-frontend-poc
   namespace: flux-config
+  labels:
+    backstage.io/kubernetes-id: ffc-ffd-frontend-poc
+    backstage.io/kubernetes-team: ffc-demo  
 spec:
   image: ${APPLICATION_ACR_NAME}.azurecr.io/image/ffc-ffd-frontend-poc
   interval: 5m0s

--- a/services/ffc/ffc-ffd/ffc-ffd-frontend-poc/infra/snd/01/image-policy.yaml
+++ b/services/ffc/ffc-ffd/ffc-ffd-frontend-poc/infra/snd/01/image-policy.yaml
@@ -3,6 +3,9 @@ kind: ImagePolicy
 metadata:
   name: ffc-ffd-frontend-poc-snd-01
   namespace: flux-config
+  labels:
+    backstage.io/kubernetes-id: ffc-ffd-frontend-poc
+    backstage.io/kubernetes-team: ffc-demo  
 spec:
   imageRepositoryRef:
     name: ffc-ffd-frontend-poc

--- a/services/ffc/ffc-ffd/ffc-ffd-frontend-poc/infra/snd/02/image-policy.yaml
+++ b/services/ffc/ffc-ffd/ffc-ffd-frontend-poc/infra/snd/02/image-policy.yaml
@@ -3,6 +3,9 @@ kind: ImagePolicy
 metadata:
   name: ffc-ffd-frontend-poc-snd-02
   namespace: flux-config
+  labels:
+    backstage.io/kubernetes-id: ffc-ffd-frontend-poc
+    backstage.io/kubernetes-team: ffc-demo  
 spec:
   imageRepositoryRef:
     name: ffc-ffd-frontend-poc

--- a/services/ffc/ffc-ffd/ffc-ffd-frontend-poc/infra/snd/03/image-policy.yaml
+++ b/services/ffc/ffc-ffd/ffc-ffd-frontend-poc/infra/snd/03/image-policy.yaml
@@ -3,6 +3,9 @@ kind: ImagePolicy
 metadata:
   name: ffc-ffd-frontend-poc-snd-03
   namespace: flux-config
+  labels:
+    backstage.io/kubernetes-id: ffc-ffd-frontend-poc
+    backstage.io/kubernetes-team: ffc-demo  
 spec:
   imageRepositoryRef:
     name: ffc-ffd-frontend-poc


### PR DESCRIPTION
# **What this PR does / why we need it**:
The ADP Portal uses the Kubernetes and Flux Backstage Plugins to display information about deployed resources in the cluster as well as the statuses of the flux manifests e.g. HelmReleases. This enables development teams to have visibility of what is running in the cluster. Relates to ADO Work Item [AB#299942](https://dev.azure.com/defragovuk/93c65135-d16b-49d6-a191-4a5313532779/_workitems/edit/299942) and builds on #3376 (link to ADO Build ID URL)*

# **Special notes for your reviewer**
The deployed resources for a given service are displayed in the Services tab in the ADP Portal.

# Testing
*Any relevant testing information and pipeline runs.*

# Checklist (please delete before completing or setting auto-complete)
- [x] Story Work items associated (not Tasks)
- [x] Successful testing run(s) link provided
- [x] Title pattern should be `{work item number}: {title}`
- [x] Description covers all the changes in the PR
- [ ] This PR contains documentation
- [ ] This PR contains tests


# **How does this PR make you feel**:
![gif](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExYnM2amQxZW9ldXU0bmdsbmc0MHNzcmVud3czYmFrdzBvdjNodWh1ZCZlcD12MV9naWZzX3NlYXJjaCZjdD1n/chzz1FQgqhytWRWbp3/giphy.gif)
