### PR TITLE
299942:  Corrected labels for FFC-FFD for flux plugin 

### DIFF
--- a/services/ffc/ffc-ffd/ffc-ffd-backend-poc/deploy-kustomize.yaml
+++ b/services/ffc/ffc-ffd/ffc-ffd-backend-poc/deploy-kustomize.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: flux-config
   labels:
     backstage.io/kubernetes-id: ffc-ffd-backend-poc
-    backstage.io/kubernetes-team: ffc-demo  
+    backstage.io/kubernetes-team: ffc-ffd  
 spec:
   dependsOn:
     - name: ffc-ffd-backend-poc-pre-deploy

--- a/services/ffc/ffc-ffd/ffc-ffd-backend-poc/deploy/base/helm-release.yaml
+++ b/services/ffc/ffc-ffd/ffc-ffd-backend-poc/deploy/base/helm-release.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: flux-config
   labels:
     backstage.io/kubernetes-id: ffc-ffd-backend-poc
-    backstage.io/kubernetes-team: ffc-demo
+    backstage.io/kubernetes-team: ffc-ffd
 spec:
   releaseName: ffc-ffd-backend-poc
   chart:

--- a/services/ffc/ffc-ffd/ffc-ffd-backend-poc/infra-kustomize.yaml
+++ b/services/ffc/ffc-ffd/ffc-ffd-backend-poc/infra-kustomize.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: flux-config
   labels:
     backstage.io/kubernetes-id: ffc-ffd-backend-poc
-    backstage.io/kubernetes-team: ffc-demo  
+    backstage.io/kubernetes-team: ffc-ffd  
 spec:
   sourceRef:
     kind: GitRepository

--- a/services/ffc/ffc-ffd/ffc-ffd-backend-poc/infra/base/aso-helm-release.yaml
+++ b/services/ffc/ffc-ffd/ffc-ffd-backend-poc/infra/base/aso-helm-release.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: flux-config
   labels:
     backstage.io/kubernetes-id: ffc-ffd-backend-poc
-    backstage.io/kubernetes-team: ffc-demo  
+    backstage.io/kubernetes-team: ffc-ffd  
 spec:
   releaseName: ffc-ffd-backend-poc-infra
   chart:

--- a/services/ffc/ffc-ffd/ffc-ffd-backend-poc/infra/base/image-repository.yaml
+++ b/services/ffc/ffc-ffd/ffc-ffd-backend-poc/infra/base/image-repository.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: flux-config
   labels:
     backstage.io/kubernetes-id: ffc-ffd-backend-poc
-    backstage.io/kubernetes-team: ffc-demo  
+    backstage.io/kubernetes-team: ffc-ffd  
 spec:
   image: ${APPLICATION_ACR_NAME}.azurecr.io/image/ffc-ffd-backend-poc
   interval: 5m0s

--- a/services/ffc/ffc-ffd/ffc-ffd-backend-poc/infra/snd/01/image-policy.yaml
+++ b/services/ffc/ffc-ffd/ffc-ffd-backend-poc/infra/snd/01/image-policy.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: flux-config
   labels:
     backstage.io/kubernetes-id: ffc-ffd-backend-poc
-    backstage.io/kubernetes-team: ffc-demo  
+    backstage.io/kubernetes-team: ffc-ffd  
 spec:
   imageRepositoryRef:
     name: ffc-ffd-backend-poc

--- a/services/ffc/ffc-ffd/ffc-ffd-backend-poc/infra/snd/02/image-policy.yaml
+++ b/services/ffc/ffc-ffd/ffc-ffd-backend-poc/infra/snd/02/image-policy.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: flux-config
   labels:
     backstage.io/kubernetes-id: ffc-ffd-backend-poc
-    backstage.io/kubernetes-team: ffc-demo  
+    backstage.io/kubernetes-team: ffc-ffd  
 spec:
   imageRepositoryRef:
     name: ffc-ffd-backend-poc

--- a/services/ffc/ffc-ffd/ffc-ffd-backend-poc/infra/snd/03/image-policy.yaml
+++ b/services/ffc/ffc-ffd/ffc-ffd-backend-poc/infra/snd/03/image-policy.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: flux-config
   labels:
     backstage.io/kubernetes-id: ffc-ffd-backend-poc
-    backstage.io/kubernetes-team: ffc-demo  
+    backstage.io/kubernetes-team: ffc-ffd  
 spec:
   imageRepositoryRef:
     name: ffc-ffd-backend-poc

--- a/services/ffc/ffc-ffd/ffc-ffd-backend-poc/pre-deploy-kustomize.yaml
+++ b/services/ffc/ffc-ffd/ffc-ffd-backend-poc/pre-deploy-kustomize.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: flux-config
   labels:
     backstage.io/kubernetes-id: ffc-ffd-backend-poc
-    backstage.io/kubernetes-team: ffc-demo  
+    backstage.io/kubernetes-team: ffc-ffd  
 spec:
   dependsOn:
     - name: ffc-ffd-backend-poc-infra

--- a/services/ffc/ffc-ffd/ffc-ffd-backend-poc/pre-deploy/migration-kustomize.yaml
+++ b/services/ffc/ffc-ffd/ffc-ffd-backend-poc/pre-deploy/migration-kustomize.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: flux-config
   labels:
     backstage.io/kubernetes-id: ffc-ffd-backend-poc
-    backstage.io/kubernetes-team: ffc-demo
+    backstage.io/kubernetes-team: ffc-ffd
 spec:
   dependsOn:
     - name: ffc-ffd-backend-poc-pre-deploy-pre-migration

--- a/services/ffc/ffc-ffd/ffc-ffd-backend-poc/pre-deploy/migration/base/image-repository-dbmigration.yaml
+++ b/services/ffc/ffc-ffd/ffc-ffd-backend-poc/pre-deploy/migration/base/image-repository-dbmigration.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: flux-config
   labels:
     backstage.io/kubernetes-id: ffc-ffd-backend-poc
-    backstage.io/kubernetes-team: ffc-demo  
+    backstage.io/kubernetes-team: ffc-ffd  
 spec:
   image: ${APPLICATION_ACR_NAME}.azurecr.io/image/ffc-ffd-backend-poc-dbmigration
   interval: 5m0s

--- a/services/ffc/ffc-ffd/ffc-ffd-backend-poc/pre-deploy/migration/base/migration.job.yaml
+++ b/services/ffc/ffc-ffd/ffc-ffd-backend-poc/pre-deploy/migration/base/migration.job.yaml
@@ -6,14 +6,14 @@ metadata:
   labels:
     azure.workload.identity/use: "true"
     backstage.io/kubernetes-id: ffc-ffd-backend-poc
-    backstage.io/kubernetes-team: ffc-demo
+    backstage.io/kubernetes-team: ffc-ffd
 spec:
   template:
     metadata:
       labels:
         azure.workload.identity/use: "true"
         backstage.io/kubernetes-id: ffc-ffd-backend-poc
-        backstage.io/kubernetes-team: ffc-demo        
+        backstage.io/kubernetes-team: ffc-ffd        
     spec:
       serviceAccountName: ${TEAM_NAMESPACE}
       restartPolicy: Never

--- a/services/ffc/ffc-ffd/ffc-ffd-backend-poc/pre-deploy/migration/snd/01/image-policy.yaml
+++ b/services/ffc/ffc-ffd/ffc-ffd-backend-poc/pre-deploy/migration/snd/01/image-policy.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: flux-config
   labels:
     backstage.io/kubernetes-id: ffc-ffd-backend-poc
-    backstage.io/kubernetes-team: ffc-demo  
+    backstage.io/kubernetes-team: ffc-ffd  
 spec:
   imageRepositoryRef:
     name: ffc-ffd-backend-poc-dbmigration

--- a/services/ffc/ffc-ffd/ffc-ffd-backend-poc/pre-deploy/migration/snd/02/image-policy.yaml
+++ b/services/ffc/ffc-ffd/ffc-ffd-backend-poc/pre-deploy/migration/snd/02/image-policy.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: flux-config
   labels:
     backstage.io/kubernetes-id: ffc-ffd-backend-poc
-    backstage.io/kubernetes-team: ffc-demo  
+    backstage.io/kubernetes-team: ffc-ffd  
 spec:
   imageRepositoryRef:
     name: ffc-ffd-backend-poc-dbmigration

--- a/services/ffc/ffc-ffd/ffc-ffd-backend-poc/pre-deploy/migration/snd/03/image-policy.yaml
+++ b/services/ffc/ffc-ffd/ffc-ffd-backend-poc/pre-deploy/migration/snd/03/image-policy.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: flux-config
   labels:
     backstage.io/kubernetes-id: ffc-ffd-backend-poc
-    backstage.io/kubernetes-team: ffc-demo  
+    backstage.io/kubernetes-team: ffc-ffd  
 spec:
   imageRepositoryRef:
     name: ffc-ffd-backend-poc-dbmigration

--- a/services/ffc/ffc-ffd/ffc-ffd-backend-poc/pre-deploy/post-migration-kustomize.yaml
+++ b/services/ffc/ffc-ffd/ffc-ffd-backend-poc/pre-deploy/post-migration-kustomize.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: flux-config
   labels:
     backstage.io/kubernetes-id: ffc-ffd-backend-poc
-    backstage.io/kubernetes-team: ffc-demo
+    backstage.io/kubernetes-team: ffc-ffd
 spec:
   dependsOn:
     - name: ffc-ffd-backend-poc-pre-deploy-migration

--- a/services/ffc/ffc-ffd/ffc-ffd-backend-poc/pre-deploy/post-migration/base/post-migration-script.job.yaml
+++ b/services/ffc/ffc-ffd/ffc-ffd-backend-poc/pre-deploy/post-migration/base/post-migration-script.job.yaml
@@ -6,14 +6,14 @@ metadata:
   labels:
     azure.workload.identity/use: "true"
     backstage.io/kubernetes-id: ffc-ffd-backend-poc
-    backstage.io/kubernetes-team: ffc-demo    
+    backstage.io/kubernetes-team: ffc-ffd    
 spec:
   template:
     metadata:
       labels:
         azure.workload.identity/use: "true"
         backstage.io/kubernetes-id: ffc-ffd-backend-poc
-        backstage.io/kubernetes-team: ffc-demo    
+        backstage.io/kubernetes-team: ffc-ffd    
     spec:
       serviceAccountName: ${TEAM_NAMESPACE}
       restartPolicy: Never

--- a/services/ffc/ffc-ffd/ffc-ffd-backend-poc/pre-deploy/pre-migration-kustomize.yaml
+++ b/services/ffc/ffc-ffd/ffc-ffd-backend-poc/pre-deploy/pre-migration-kustomize.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: flux-config
   labels:
     backstage.io/kubernetes-id: ffc-ffd-backend-poc
-    backstage.io/kubernetes-team: ffc-demo  
+    backstage.io/kubernetes-team: ffc-ffd  
 spec:
   sourceRef:
     kind: GitRepository

--- a/services/ffc/ffc-ffd/ffc-ffd-backend-poc/pre-deploy/pre-migration/base/pre-migration-script.job.yaml
+++ b/services/ffc/ffc-ffd/ffc-ffd-backend-poc/pre-deploy/pre-migration/base/pre-migration-script.job.yaml
@@ -6,14 +6,14 @@ metadata:
   labels:
     azure.workload.identity/use: "true"
     backstage.io/kubernetes-id: ffc-ffd-backend-poc
-    backstage.io/kubernetes-team: ffc-demo
+    backstage.io/kubernetes-team: ffc-ffd
 spec:
   template:
     metadata:
       labels:
         azure.workload.identity/use: "true"
         backstage.io/kubernetes-id: ffc-ffd-backend-poc
-        backstage.io/kubernetes-team: ffc-demo
+        backstage.io/kubernetes-team: ffc-ffd
     spec:
       serviceAccountName: ${PLATFORM_DB_ADMIN}
       restartPolicy: Never

--- a/services/ffc/ffc-ffd/ffc-ffd-frontend-poc/deploy-kustomize.yaml
+++ b/services/ffc/ffc-ffd/ffc-ffd-frontend-poc/deploy-kustomize.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: flux-config
   labels:
     backstage.io/kubernetes-id: ffc-ffd-frontend-poc
-    backstage.io/kubernetes-team: ffc-demo  
+    backstage.io/kubernetes-team: ffc-ffd  
 spec:
   dependsOn:
     - name: ffc-ffd-frontend-poc-infra

--- a/services/ffc/ffc-ffd/ffc-ffd-frontend-poc/deploy/base/helm-release.yaml
+++ b/services/ffc/ffc-ffd/ffc-ffd-frontend-poc/deploy/base/helm-release.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: flux-config
   labels:
     backstage.io/kubernetes-id: ffc-ffd-frontend-poc
-    backstage.io/kubernetes-team: ffc-demo
+    backstage.io/kubernetes-team: ffc-ffd
 spec:
   releaseName: ffc-ffd-frontend-poc
   chart:

--- a/services/ffc/ffc-ffd/ffc-ffd-frontend-poc/infra-kustomize.yaml
+++ b/services/ffc/ffc-ffd/ffc-ffd-frontend-poc/infra-kustomize.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: flux-config
   labels:
     backstage.io/kubernetes-id: ffc-ffd-frontend-poc
-    backstage.io/kubernetes-team: ffc-demo  
+    backstage.io/kubernetes-team: ffc-ffd  
 spec:
   sourceRef:
     kind: GitRepository

--- a/services/ffc/ffc-ffd/ffc-ffd-frontend-poc/infra/base/aso-helm-release.yaml
+++ b/services/ffc/ffc-ffd/ffc-ffd-frontend-poc/infra/base/aso-helm-release.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: flux-config
   labels:
     backstage.io/kubernetes-id: ffc-ffd-frontend-poc
-    backstage.io/kubernetes-team: ffc-demo  
+    backstage.io/kubernetes-team: ffc-ffd  
 spec:
   releaseName: ffc-ffd-frontend-poc-infra
   chart:

--- a/services/ffc/ffc-ffd/ffc-ffd-frontend-poc/infra/base/image-repository.yaml
+++ b/services/ffc/ffc-ffd/ffc-ffd-frontend-poc/infra/base/image-repository.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: flux-config
   labels:
     backstage.io/kubernetes-id: ffc-ffd-frontend-poc
-    backstage.io/kubernetes-team: ffc-demo  
+    backstage.io/kubernetes-team: ffc-ffd  
 spec:
   image: ${APPLICATION_ACR_NAME}.azurecr.io/image/ffc-ffd-frontend-poc
   interval: 5m0s

--- a/services/ffc/ffc-ffd/ffc-ffd-frontend-poc/infra/snd/01/image-policy.yaml
+++ b/services/ffc/ffc-ffd/ffc-ffd-frontend-poc/infra/snd/01/image-policy.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: flux-config
   labels:
     backstage.io/kubernetes-id: ffc-ffd-frontend-poc
-    backstage.io/kubernetes-team: ffc-demo  
+    backstage.io/kubernetes-team: ffc-ffd  
 spec:
   imageRepositoryRef:
     name: ffc-ffd-frontend-poc

--- a/services/ffc/ffc-ffd/ffc-ffd-frontend-poc/infra/snd/02/image-policy.yaml
+++ b/services/ffc/ffc-ffd/ffc-ffd-frontend-poc/infra/snd/02/image-policy.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: flux-config
   labels:
     backstage.io/kubernetes-id: ffc-ffd-frontend-poc
-    backstage.io/kubernetes-team: ffc-demo  
+    backstage.io/kubernetes-team: ffc-ffd  
 spec:
   imageRepositoryRef:
     name: ffc-ffd-frontend-poc

--- a/services/ffc/ffc-ffd/ffc-ffd-frontend-poc/infra/snd/03/image-policy.yaml
+++ b/services/ffc/ffc-ffd/ffc-ffd-frontend-poc/infra/snd/03/image-policy.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: flux-config
   labels:
     backstage.io/kubernetes-id: ffc-ffd-frontend-poc
-    backstage.io/kubernetes-team: ffc-demo  
+    backstage.io/kubernetes-team: ffc-ffd  
 spec:
   imageRepositoryRef:
     name: ffc-ffd-frontend-poc


### PR DESCRIPTION
# **What this PR does / why we need it**:
The ADP Portal uses the Kubernetes and Flux Backstage Plugins to display information about deployed resources in the cluster as well as the statuses of the flux manifests e.g. HelmReleases. This PR contains changes to correct the labels for the FFC-FFD team. Relates to ADO Work Item [AB#299942](https://dev.azure.com/defragovuk/93c65135-d16b-49d6-a191-4a5313532779/_workitems/edit/299942) and builds on #3376 (link to ADO Build ID URL)*

# **Special notes for your reviewer**
The deployed resources for a given service are displayed in the Services tab in the ADP Portal.

# Testing
*Any relevant testing information and pipeline runs.*

# Checklist (please delete before completing or setting auto-complete)
- [x] Story Work items associated (not Tasks)
- [x] Successful testing run(s) link provided
- [x] Title pattern should be `{work item number}: {title}`
- [x] Description covers all the changes in the PR
- [ ] This PR contains documentation
- [ ] This PR contains tests


# **How does this PR make you feel**:
![gif](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExYnM2amQxZW9ldXU0bmdsbmc0MHNzcmVud3czYmFrdzBvdjNodWh1ZCZlcD12MV9naWZzX3NlYXJjaCZjdD1n/chzz1FQgqhytWRWbp3/giphy.gif)
