### PR TITLE
248312: Add pod to pod network policy back in at base level

### DIFF
--- a/services/base/kustomization.yaml
+++ b/services/base/kustomization.yaml
@@ -12,4 +12,5 @@ resources:
   - aso/team-secret.yaml
   - aso/team-federated-credential.yaml
   - team-service-account.yaml
+  - network-policy.yaml
   

--- a/services/base/network-policy.yaml
+++ b/services/base/network-policy.yaml
@@ -1,0 +1,16 @@
+apiVersion: projectcalico.org/v3
+kind: NetworkPolicy
+metadata:
+  name: allow-${TEAM_NAMESPACE}-internal
+  namespace: ${TEAM_NAMESPACE}
+spec:
+  ingress:
+    - action: Allow
+      protocol: TCP
+      source:
+        namespaceSelector: kubernetes.io/metadata.name == '${TEAM_NAMESPACE}'
+  egress:
+    - action: Allow
+      protocol: TCP
+      destination:
+        namespaceSelector: kubernetes.io/metadata.name == '${TEAM_NAMESPACE}'


### PR DESCRIPTION
# **What this PR does / why we need it**:
This PR applies a Calico Network policy which allows pod to pod communication within a team namespace.  

*A brief description of changes being made*
[AB#248312](https://dev.azure.com/defragovuk/93c65135-d16b-49d6-a191-4a5313532779/_workitems/edit/248312)

# Testing
Tested in SND1 successfully

# Checklist (please delete before completing or setting auto-complete)
- [x] Story Work items associated (not Tasks)
- [ ] Successful testing run(s) link provided
- [x] Title pattern should be `{work item number}: {title}`
- [x] Description covers all the changes in the PR
- [ ] This PR contains documentation
- [ ] This PR contains tests


# **How does this PR make you feel**:
![gif]([https://giphy.com/)
