### PR TITLE
305668: Added quotes to DB port number to ensure flux kustomize substitution works with no errors

### DIFF
--- a/services/coreai/coreai-mcu/coreai-mcu-knowledge-pgv/pre-deploy-kustomize.yaml
+++ b/services/coreai/coreai-mcu/coreai-mcu-knowledge-pgv/pre-deploy-kustomize.yaml
@@ -28,7 +28,7 @@ spec:
       TEAM_NAME: ${TEAM_NAME}
       PLATFORM_DB_ADMIN: ${PLATFORM_DB_ADMIN}
       POSTGRES_DB: coreai-mcu-knowledge
-      POSTGRES_PORT: 5432
+      POSTGRES_PORT: "5432"
       POSTGRES_SCHEMA_NAME: public
     substituteFrom:
     - kind: ConfigMap


### PR DESCRIPTION
# **What this PR does / why we need it**:
Adds quotes to the DB Port number. This is required for the Flux PostBuild kustomize substititution.

Relates to ADO Work Item [AB#305668](https://dev.azure.com/defragovuk/93c65135-d16b-49d6-a191-4a5313532779/_workitems/edit/305668)

# **Special notes for your reviewer**
*Any specific actions or notes on review?*

# Testing
*Any relevant testing information and pipeline runs.*

# Checklist (please delete before completing or setting auto-complete)
- [ ] Story Work items associated (not Tasks)
- [ ] Successful testing run(s) link provided
- [ ] Title pattern should be `{work item number}: {title}`
- [ ] Description covers all the changes in the PR
- [ ] This PR contains documentation
- [ ] This PR contains tests


# **How does this PR make you feel**:
![gif]([https://giphy.com/)
