### PR TITLE
353142: Pass environment id along with name in Flux Notification

### DIFF
--- a/services/environments/snd/base/notification.yaml
+++ b/services/environments/snd/base/notification.yaml
@@ -16,7 +16,7 @@ metadata:
   namespace: flux-config
 spec:
   eventMetadata:
-    env: "${ENVIRONMENT}"
+    env: "${ENVIRONMENT}${ENVIRONMENT_ID}"
     cluster: "${CLUSTER_NAME}"
   providerRef:
     name: azureeventhub


### PR DESCRIPTION
# **What this PR does / why we need it**:
We need to be able to identify which environment the flux notification is coming from.  In order to do this we need to pass the environment id as part of the notifcation

[AB#353142](https://dev.azure.com/defragovuk/93c65135-d16b-49d6-a191-4a5313532779/_workitems/edit/353142)

# **Special notes for your reviewer**
*Any specific actions or notes on review?*

# Testing
*Any relevant testing information and pipeline runs.*

# Checklist (please delete before completing or setting auto-complete)
- [x] Story Work items associated (not Tasks)
- [ ] Successful testing run(s) link provided
- [x] Title pattern should be `{work item number}: {title}`
- [x] Description covers all the changes in the PR
- [ ] This PR contains documentation
- [ ] This PR contains tests


# **How does this PR make you feel**:
![gif]([https://giphy.com/)
