### PR TITLE
353142: Append envrionment id to cluster name in Flux notification

### DIFF
--- a/services/environments/dev/base/notification.yaml
+++ b/services/environments/dev/base/notification.yaml
@@ -16,7 +16,7 @@ metadata:
   namespace: flux-config
 spec:
   eventMetadata:
-    env: "${ENVIRONMENT}"
+    env: "${ENVIRONMENT}${ENVIRONMENT_ID}"
     cluster: "${CLUSTER_NAME}"
   providerRef:
     name: azureeventhub

--- a/services/environments/prd/base/notification.yaml
+++ b/services/environments/prd/base/notification.yaml
@@ -16,7 +16,7 @@ metadata:
   namespace: flux-config
 spec:
   eventMetadata:
-    env: "${ENVIRONMENT}"
+    env: "${ENVIRONMENT}${ENVIRONMENT_ID}"
     cluster: "${CLUSTER_NAME}"
   providerRef:
     name: azureeventhub

--- a/services/environments/pre/base/notification.yaml
+++ b/services/environments/pre/base/notification.yaml
@@ -16,7 +16,7 @@ metadata:
   namespace: flux-config
 spec:
   eventMetadata:
-    env: "${ENVIRONMENT}"
+    env: "${ENVIRONMENT}${ENVIRONMENT_ID}"
     cluster: "${CLUSTER_NAME}"
   providerRef:
     name: azureeventhub

--- a/services/environments/tst/base/notification.yaml
+++ b/services/environments/tst/base/notification.yaml
@@ -16,7 +16,7 @@ metadata:
   namespace: flux-config
 spec:
   eventMetadata:
-    env: "${ENVIRONMENT}"
+    env: "${ENVIRONMENT}${ENVIRONMENT_ID}"
     cluster: "${CLUSTER_NAME}"
   providerRef:
     name: azureeventhub


### PR DESCRIPTION
Append environment id to AKS cluster name in Flux Notification.

[AB#353142](https://dev.azure.com/defragovuk/93c65135-d16b-49d6-a191-4a5313532779/_workitems/edit/353142)

# **Special notes for your reviewer**
*Any specific actions or notes on review?*

# Testing
*Any relevant testing information and pipeline runs.*

# Checklist (please delete before completing or setting auto-complete)
- [x] Story Work items associated (not Tasks)
- [x] Successful testing run(s) link provided
- [ ] Title pattern should be `{work item number}: {title}`
- [x] Description covers all the changes in the PR
- [ ] This PR contains documentation
- [ ] This PR contains tests


# **How does this PR make you feel**:
![gif]([https://giphy.com/)
