### PR TITLE
353142: Separated the Writer and Read Role Scripts so that permissions can be assigned using the correct roles

### DIFF
--- a/common/scripts/access-control/flexible-server/Grant-FlexibleServerAccess-Job.ps1
+++ b/common/scripts/access-control/flexible-server/Grant-FlexibleServerAccess-Job.ps1
@@ -83,8 +83,8 @@ function Get-SQLScriptToGrantAllPermissions {
     [void]$builder.Append("GRANT ALL ON ALL SEQUENCES IN SCHEMA public TO `"$PostgresWriterAdGroup`";")
     [void]$builder.Append("GRANT ALL ON ALL FUNCTIONS IN SCHEMA public TO `"$PostgresWriterAdGroup`";")
     [void]$builder.Append("GRANT ALL ON ALL PROCEDURES IN SCHEMA public TO `"$PostgresWriterAdGroup`";")
-    [void]$builder.Append("ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON TABLES TO `"$PostgresReaderAdGroup`";")
-    [void]$builder.Append("ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON SEQUENCES TO `"$PostgresReaderAdGroup`";")
+    [void]$builder.Append("ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON TABLES TO `"$PostgresWriterAdGroup`";")
+    [void]$builder.Append("ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON SEQUENCES TO `"$PostgresWriterAdGroup`";")
     return $builder.ToString()
 }
 

--- a/common/scripts/access-control/flexible-server/Grant-FlexibleServerAccess-NotifyDB-Reader.ps1
+++ b/common/scripts/access-control/flexible-server/Grant-FlexibleServerAccess-NotifyDB-Reader.ps1
@@ -13,7 +13,6 @@ Set-StrictMode -Version 3.0
 
 [string]$PostgresHost = $env:POSTGRES_HOST 
 [string]$PostgresDatabase = $env:POSTGRES_DATABASE
-[string]$PlatformMIName = $env:PLATFORM_MI_NAME 
 [string]$PlatformMIClientId = $env:AZURE_CLIENT_ID
 [string]$PlatformMITenantId = $env:AZURE_TENANT_ID
 [string]$PlatformMISubscriptionId = $env:PLATFORM_MI_SUBSCRIPTION_ID 
@@ -39,7 +38,6 @@ if ($enableDebug) {
 Write-Host "${functionName} started at $($startTime.ToString('u'))"
 Write-Debug "${functionName}:PostgresHost:$PostgresHost"
 Write-Debug "${functionName}:PostgresDatabase:$PostgresDatabase"
-Write-Debug "${functionName}:PlatformMIName:$PlatformMIName"
 Write-Debug "${functionName}:SubscriptionName=$SubscriptionName"
 Write-Debug "${functionName}:WorkingDirectory=$WorkingDirectory"
 Write-Debug "${functionName}:PostgresReaderAdGroup=$PostgresReaderAdGroup"
@@ -84,7 +82,7 @@ try {
     Write-Debug "${functionName}:$($assignReadPermissionsTempFile.FullName)=$content"
 
     Write-Host "Granting permissions to ${PostgresReaderAdGroup}"
-    $null = Invoke-PSQLScript -PostgresHost $PostgresHost -PostgresDatabase $PostgresDatabase -PostgresUsername $PlatformMIName -Path $assignReadPermissionsTempFile.FullName
+    $null = Invoke-PSQLScript -PostgresHost $PostgresHost -PostgresDatabase $PostgresDatabase -PostgresUsername $PostgresWriterAdGroup -Path $assignReadPermissionsTempFile.FullName
     Write-Host "Granted Access to ${PostgresReaderAdGroup}"
 
     # Successful exit

--- a/common/scripts/access-control/flexible-server/Grant-FlexibleServerAccess-NotifyDB-Reader.ps1
+++ b/common/scripts/access-control/flexible-server/Grant-FlexibleServerAccess-NotifyDB-Reader.ps1
@@ -13,7 +13,7 @@ Set-StrictMode -Version 3.0
 
 [string]$PostgresHost = $env:POSTGRES_HOST 
 [string]$PostgresDatabase = $env:POSTGRES_DATABASE
-[string]$PlatformMIClientId = $env:AZURE_CLIENT_ID
+[string]$NotificationApiMIClientId = $env:AZURE_CLIENT_ID
 [string]$PlatformMITenantId = $env:AZURE_TENANT_ID
 [string]$PlatformMISubscriptionId = $env:PLATFORM_MI_SUBSCRIPTION_ID 
 [string]$SubscriptionName = $env:SUBSCRIPTION_NAME
@@ -66,7 +66,7 @@ try {
     Import-Module $moduleDir.FullName -Force
 
     Write-Host "Connecting to Azure..."
-    $azureContext = (Connect-AzAccount -Identity -AccountId $PlatformMIClientId -Tenant $PlatformMITenantId -Subscription $PlatformMISubscriptionId).context
+    $azureContext = (Connect-AzAccount -Identity -AccountId $NotificationApiMIClientId -Tenant $PlatformMITenantId -Subscription $PlatformMISubscriptionId).context
     $null = Set-AzContext -Subscription $SubscriptionName -DefaultProfile $azureContext
     Write-Host "Connected to Azure and set context to '$SubscriptionName'"
 

--- a/common/scripts/access-control/flexible-server/Grant-FlexibleServerAccess-NotifyDB-Reader.ps1
+++ b/common/scripts/access-control/flexible-server/Grant-FlexibleServerAccess-NotifyDB-Reader.ps1
@@ -48,49 +48,8 @@ Write-Debug "${functionName}:PostgresWriterAdGroup=$PostgresWriterAdGroup"
 [System.IO.DirectoryInfo]$scriptDir = $PSCommandPath | Split-Path -Parent
 Write-Debug "${functionName}:scriptDir.FullName:$($scriptDir.FullName)"
 
-function Get-SQLScriptToCreatePrincipal {
-    [System.Text.StringBuilder]$builder = [System.Text.StringBuilder]::new()
-    [void]$builder.Append(' DO $$ ')
-    [void]$builder.Append(' BEGIN ')
-    [void]$builder.Append("     IF NOT EXISTS (SELECT 1 FROM pgaadauth_list_principals(false) WHERE rolname='$PostgresWriterAdGroup') THEN ")
-    [void]$builder.Append("         RAISE NOTICE 'CREATING PRINCIPAL FOR MANAGED IDENTITY:$PostgresWriterAdGroup';")
-    [void]$builder.Append("         PERFORM pgaadauth_create_principal('$PostgresWriterAdGroup', false, false); ");
-    [void]$builder.Append("         RAISE NOTICE 'PRINCIPAL FOR MANAGED IDENTITY CREATED:$PostgresWriterAdGroup';")
-    [void]$builder.Append('     ELSE ')
-    [void]$builder.Append("         RAISE NOTICE 'PRINCIPAL FOR MANAGED IDENTITY ALREADY EXISTS:$PostgresWriterAdGroup';")
-    [void]$builder.Append('     END IF; ')
-    [void]$builder.Append("     IF NOT EXISTS (SELECT 1 FROM pgaadauth_list_principals(false) WHERE rolname='$PostgresReaderAdGroup') THEN ")
-    [void]$builder.Append("         RAISE NOTICE 'CREATING PRINCIPAL FOR MANAGED IDENTITY:$PostgresReaderAdGroup';")
-    [void]$builder.Append("         PERFORM pgaadauth_create_principal('$PostgresReaderAdGroup', false, false); ");
-    [void]$builder.Append("         RAISE NOTICE 'PRINCIPAL FOR MANAGED IDENTITY CREATED:$PostgresReaderAdGroup';")
-    [void]$builder.Append('     ELSE ')
-    [void]$builder.Append("         RAISE NOTICE 'PRINCIPAL FOR MANAGED IDENTITY ALREADY EXISTS:$PostgresReaderAdGroup';")
-    [void]$builder.Append('     END IF; ')
-    [void]$builder.Append("     EXECUTE ( 'GRANT CONNECT ON DATABASE `"$PostgresDatabase`" TO `"$PostgresWriterAdGroup`"' );")
-    [void]$builder.Append("     EXECUTE ( 'GRANT CONNECT ON DATABASE `"$PostgresDatabase`" TO `"$PostgresReaderAdGroup`"' );")
-    [void]$builder.Append("     RAISE NOTICE 'GRANTED CONNECT TO DATABASE';")
-    [void]$builder.Append(" EXCEPTION ")
-    [void]$builder.Append("     WHEN OTHERS THEN  ")
-    [void]$builder.Append("         RAISE EXCEPTION 'ERROR DURING PRINCIPAL CREATION/GRANT CONNECT: %', SQLERRM; ")
-    [void]$builder.Append(' END $$' )
-    return $builder.ToString()
-}
-
-function Get-SQLScriptToGrantAllPermissions {
-    [System.Text.StringBuilder]$builder = [System.Text.StringBuilder]::new()
-    [void]$builder.Append("GRANT ALL ON SCHEMA public TO `"$PostgresWriterAdGroup`";")
-    [void]$builder.Append("GRANT ALL ON ALL TABLES IN SCHEMA public TO `"$PostgresWriterAdGroup`";")
-    [void]$builder.Append("GRANT ALL ON ALL SEQUENCES IN SCHEMA public TO `"$PostgresWriterAdGroup`";")
-    [void]$builder.Append("GRANT ALL ON ALL FUNCTIONS IN SCHEMA public TO `"$PostgresWriterAdGroup`";")
-    [void]$builder.Append("GRANT ALL ON ALL PROCEDURES IN SCHEMA public TO `"$PostgresWriterAdGroup`";")
-    [void]$builder.Append("ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON TABLES TO `"$PostgresWriterAdGroup`";")
-    [void]$builder.Append("ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON SEQUENCES TO `"$PostgresWriterAdGroup`";")
-    return $builder.ToString()
-}
-
 function Get-SQLScriptToGrantReadPermissions {
     [System.Text.StringBuilder]$builder = [System.Text.StringBuilder]::new()
-    [void]$builder.Append("GRANT USAGE ON SCHEMA public TO `"$PostgresReaderAdGroup`";")
     [void]$builder.Append("GRANT SELECT ON ALL TABLES IN SCHEMA public TO `"$PostgresReaderAdGroup`";")
     [void]$builder.Append("GRANT SELECT ON ALL SEQUENCES IN SCHEMA public TO `"$PostgresReaderAdGroup`";")
     [void]$builder.Append("REVOKE EXECUTE ON ALL FUNCTIONS IN SCHEMA public FROM `"$PostgresReaderAdGroup`";")
@@ -101,8 +60,6 @@ function Get-SQLScriptToGrantReadPermissions {
 }
 
 [string]$tempFolder=[System.IO.Path]::GetTempPath()
-[System.IO.FileInfo]$createPrincipalTempFile = $tempFolder + $(New-Guid).ToString() + ".sql";
-[System.IO.FileInfo]$assignAllPermissionsTempFile = $tempFolder + $(New-Guid).ToString() + ".sql";
 [System.IO.FileInfo]$assignReadPermissionsTempFile = $tempFolder + $(New-Guid).ToString() + ".sql";
 
 try {
@@ -119,26 +76,6 @@ try {
     $accessToken = Get-AzAccessToken -ResourceUrl "https://ossrdbms-aad.database.windows.net"
     $ENV:PGPASSWORD = $accessToken.Token
     Write-Host "Access Token Acquired"
-
-    [string]$command = Get-SQLScriptToCreatePrincipal
-    Write-Debug "${functionName}:command=$command"
-    
-    [string]$content = Set-Content -Path $createPrincipalTempFile.FullName -Value $command -PassThru -Force
-    Write-Debug "${functionName}:$($createPrincipalTempFile.FullName)=$content"
-
-    Write-Host "Creating Principal in ${PostgresHost} and Granting connect permissions"
-    $null = Invoke-PSQLScript -PostgresHost $PostgresHost -PostgresDatabase "postgres" -PostgresUsername $PlatformMIName -Path $createPrincipalTempFile.FullName
-    Write-Host "Granted Access to ${PostgresHost}"
-
-    [string]$command = Get-SQLScriptToGrantAllPermissions
-    Write-Debug "${functionName}:command=$command"
-    
-    [string]$content = Set-Content -Path $assignAllPermissionsTempFile.FullName -Value $command -PassThru -Force
-    Write-Debug "${functionName}:$($assignAllPermissionsTempFile.FullName)=$content"
-
-    Write-Host "Granting permissions to ${PostgresWriterAdGroup}"
-    $null = Invoke-PSQLScript -PostgresHost $PostgresHost -PostgresDatabase $PostgresDatabase -PostgresUsername $PlatformMIName -Path $assignAllPermissionsTempFile.FullName
-    Write-Host "Granted Access to ${PostgresWriterAdGroup}"
 
     [string]$command = Get-SQLScriptToGrantReadPermissions
     Write-Debug "${functionName}:command=$command"
@@ -159,8 +96,6 @@ catch {
     throw $_.Exception
 }
 finally {
-    Remove-Item -Path $createPrincipalTempFile.FullName -Force -ErrorAction SilentlyContinue
-    Remove-Item -Path $assignAllPermissionsTempFile.FullName -Force -ErrorAction SilentlyContinue
     Remove-Item -Path $assignReadPermissionsTempFile.FullName -Force -ErrorAction SilentlyContinue
 
     [DateTime]$endTime = [DateTime]::UtcNow

--- a/common/scripts/access-control/flexible-server/Grant-FlexibleServerAccess-NotifyDB-Writer.ps1
+++ b/common/scripts/access-control/flexible-server/Grant-FlexibleServerAccess-NotifyDB-Writer.ps1
@@ -1,0 +1,153 @@
+<#
+.SYNOPSIS
+Grant access to postgres flexible server for service (tier-3) managed identity.
+
+.DESCRIPTION
+Grant access to postgres flexible server for service (tier-3) managed identity.
+
+.EXAMPLE
+.\Grant-FlexibleServerAccess.ps1 
+#>
+
+Set-StrictMode -Version 3.0
+
+[string]$PostgresHost = $env:POSTGRES_HOST 
+[string]$PostgresDatabase = $env:POSTGRES_DATABASE
+[string]$PlatformMIName = $env:PLATFORM_MI_NAME 
+[string]$PlatformMIClientId = $env:AZURE_CLIENT_ID
+[string]$PlatformMITenantId = $env:AZURE_TENANT_ID
+[string]$PlatformMISubscriptionId = $env:PLATFORM_MI_SUBSCRIPTION_ID 
+[string]$SubscriptionName = $env:SUBSCRIPTION_NAME
+[string]$WorkingDirectory = $PWD
+[string]$PostgresReaderAdGroup = $env:PG_READER_AD_GROUP
+[string]$PostgresWriterAdGroup = $env:PG_WRITER_AD_GROUP
+
+[string]$functionName = $MyInvocation.MyCommand
+[DateTime]$startTime = [DateTime]::UtcNow
+[int]$exitCode = -1
+[bool]$setHostExitCode = (Test-Path -Path ENV:TF_BUILD) -and ($ENV:TF_BUILD -eq "true")
+[bool]$enableDebug = (Test-Path -Path ENV:SYSTEM_DEBUG) -and ($ENV:SYSTEM_DEBUG -eq "true")
+
+Set-Variable -Name ErrorActionPreference -Value Continue -scope global
+Set-Variable -Name VerbosePreference -Value Continue -Scope global
+
+if ($enableDebug) {
+    Set-Variable -Name DebugPreference -Value Continue -Scope global
+    Set-Variable -Name InformationPreference -Value Continue -Scope global
+}
+
+Write-Host "${functionName} started at $($startTime.ToString('u'))"
+Write-Debug "${functionName}:PostgresHost:$PostgresHost"
+Write-Debug "${functionName}:PostgresDatabase:$PostgresDatabase"
+Write-Debug "${functionName}:PlatformMIName:$PlatformMIName"
+Write-Debug "${functionName}:SubscriptionName=$SubscriptionName"
+Write-Debug "${functionName}:WorkingDirectory=$WorkingDirectory"
+Write-Debug "${functionName}:PostgresReaderAdGroup=$PostgresReaderAdGroup"
+Write-Debug "${functionName}:PostgresWriterAdGroup=$PostgresWriterAdGroup"
+
+[System.IO.DirectoryInfo]$scriptDir = $PSCommandPath | Split-Path -Parent
+Write-Debug "${functionName}:scriptDir.FullName:$($scriptDir.FullName)"
+
+function Get-SQLScriptToCreatePrincipal {
+    [System.Text.StringBuilder]$builder = [System.Text.StringBuilder]::new()
+    [void]$builder.Append(' DO $$ ')
+    [void]$builder.Append(' BEGIN ')
+    [void]$builder.Append("     IF NOT EXISTS (SELECT 1 FROM pgaadauth_list_principals(false) WHERE rolname='$PostgresWriterAdGroup') THEN ")
+    [void]$builder.Append("         RAISE NOTICE 'CREATING PRINCIPAL FOR MANAGED IDENTITY:$PostgresWriterAdGroup';")
+    [void]$builder.Append("         PERFORM pgaadauth_create_principal('$PostgresWriterAdGroup', false, false); ");
+    [void]$builder.Append("         RAISE NOTICE 'PRINCIPAL FOR MANAGED IDENTITY CREATED:$PostgresWriterAdGroup';")
+    [void]$builder.Append('     ELSE ')
+    [void]$builder.Append("         RAISE NOTICE 'PRINCIPAL FOR MANAGED IDENTITY ALREADY EXISTS:$PostgresWriterAdGroup';")
+    [void]$builder.Append('     END IF; ')
+    [void]$builder.Append("     IF NOT EXISTS (SELECT 1 FROM pgaadauth_list_principals(false) WHERE rolname='$PostgresReaderAdGroup') THEN ")
+    [void]$builder.Append("         RAISE NOTICE 'CREATING PRINCIPAL FOR MANAGED IDENTITY:$PostgresReaderAdGroup';")
+    [void]$builder.Append("         PERFORM pgaadauth_create_principal('$PostgresReaderAdGroup', false, false); ");
+    [void]$builder.Append("         RAISE NOTICE 'PRINCIPAL FOR MANAGED IDENTITY CREATED:$PostgresReaderAdGroup';")
+    [void]$builder.Append('     ELSE ')
+    [void]$builder.Append("         RAISE NOTICE 'PRINCIPAL FOR MANAGED IDENTITY ALREADY EXISTS:$PostgresReaderAdGroup';")
+    [void]$builder.Append('     END IF; ')
+    [void]$builder.Append("     EXECUTE ( 'GRANT CONNECT ON DATABASE `"$PostgresDatabase`" TO `"$PostgresWriterAdGroup`"' );")
+    [void]$builder.Append("     EXECUTE ( 'GRANT CONNECT ON DATABASE `"$PostgresDatabase`" TO `"$PostgresReaderAdGroup`"' );")
+    [void]$builder.Append("     RAISE NOTICE 'GRANTED CONNECT TO DATABASE';")
+    [void]$builder.Append(" EXCEPTION ")
+    [void]$builder.Append("     WHEN OTHERS THEN  ")
+    [void]$builder.Append("         RAISE EXCEPTION 'ERROR DURING PRINCIPAL CREATION/GRANT CONNECT: %', SQLERRM; ")
+    [void]$builder.Append(' END $$' )
+    return $builder.ToString()
+}
+
+function Get-SQLScriptToGrantAllPermissions {
+    [System.Text.StringBuilder]$builder = [System.Text.StringBuilder]::new()
+    [void]$builder.Append("GRANT ALL ON SCHEMA public TO `"$PostgresWriterAdGroup`";")
+    [void]$builder.Append("GRANT USAGE ON SCHEMA public TO `"$PostgresReaderAdGroup`";")
+    [void]$builder.Append("GRANT ALL ON ALL TABLES IN SCHEMA public TO `"$PostgresWriterAdGroup`";")
+    [void]$builder.Append("GRANT ALL ON ALL SEQUENCES IN SCHEMA public TO `"$PostgresWriterAdGroup`";")
+    [void]$builder.Append("GRANT ALL ON ALL FUNCTIONS IN SCHEMA public TO `"$PostgresWriterAdGroup`";")
+    [void]$builder.Append("GRANT ALL ON ALL PROCEDURES IN SCHEMA public TO `"$PostgresWriterAdGroup`";")
+    [void]$builder.Append("ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON TABLES TO `"$PostgresWriterAdGroup`";")
+    [void]$builder.Append("ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON SEQUENCES TO `"$PostgresWriterAdGroup`";")
+    return $builder.ToString()
+}
+
+[string]$tempFolder=[System.IO.Path]::GetTempPath()
+[System.IO.FileInfo]$createPrincipalTempFile = $tempFolder + $(New-Guid).ToString() + ".sql";
+[System.IO.FileInfo]$assignAllPermissionsTempFile = $tempFolder + $(New-Guid).ToString() + ".sql";
+
+try {
+    [System.IO.DirectoryInfo]$moduleDir = Join-Path -Path $WorkingDirectory -ChildPath "common/scripts/modules/psql"
+    Write-Debug "${functionName}:moduleDir.FullName=$($moduleDir.FullName)"
+    Import-Module $moduleDir.FullName -Force
+
+    Write-Host "Connecting to Azure..."
+    $azureContext = (Connect-AzAccount -Identity -AccountId $PlatformMIClientId -Tenant $PlatformMITenantId -Subscription $PlatformMISubscriptionId).context
+    $null = Set-AzContext -Subscription $SubscriptionName -DefaultProfile $azureContext
+    Write-Host "Connected to Azure and set context to '$SubscriptionName'"
+
+    Write-Host "Acquiring Access Token..."
+    $accessToken = Get-AzAccessToken -ResourceUrl "https://ossrdbms-aad.database.windows.net"
+    $ENV:PGPASSWORD = $accessToken.Token
+    Write-Host "Access Token Acquired"
+
+    [string]$command = Get-SQLScriptToCreatePrincipal
+    Write-Debug "${functionName}:command=$command"
+    
+    [string]$content = Set-Content -Path $createPrincipalTempFile.FullName -Value $command -PassThru -Force
+    Write-Debug "${functionName}:$($createPrincipalTempFile.FullName)=$content"
+
+    Write-Host "Creating Principal in ${PostgresHost} and Granting connect permissions"
+    $null = Invoke-PSQLScript -PostgresHost $PostgresHost -PostgresDatabase "postgres" -PostgresUsername $PlatformMIName -Path $createPrincipalTempFile.FullName
+    Write-Host "Granted Access to ${PostgresHost}"
+
+    [string]$command = Get-SQLScriptToGrantAllPermissions
+    Write-Debug "${functionName}:command=$command"
+    
+    [string]$content = Set-Content -Path $assignAllPermissionsTempFile.FullName -Value $command -PassThru -Force
+    Write-Debug "${functionName}:$($assignAllPermissionsTempFile.FullName)=$content"
+
+    Write-Host "Granting permissions to ${PostgresWriterAdGroup}"
+    $null = Invoke-PSQLScript -PostgresHost $PostgresHost -PostgresDatabase $PostgresDatabase -PostgresUsername $PlatformMIName -Path $assignAllPermissionsTempFile.FullName
+    Write-Host "Granted Access to ${PostgresWriterAdGroup}"
+
+    # Successful exit
+    $exitCode = 0
+} 
+catch {
+    $exitCode = -2
+    Write-Error $_.Exception.ToString()
+    throw $_.Exception
+}
+finally {
+    Remove-Item -Path $createPrincipalTempFile.FullName -Force -ErrorAction SilentlyContinue
+    Remove-Item -Path $assignAllPermissionsTempFile.FullName -Force -ErrorAction SilentlyContinue
+
+    [DateTime]$endTime = [DateTime]::UtcNow
+    [Timespan]$duration = $endTime.Subtract($startTime)
+
+    Write-Host "${functionName} finished at $($endTime.ToString('u')) (duration $($duration -f 'g')) with exit code $exitCode"
+
+    if ($setHostExitCode) {
+        Write-Debug "${functionName}:Setting host exit code"
+        $host.SetShouldExit($exitCode)
+    }
+    exit $exitCode
+}


### PR DESCRIPTION
# **What this PR does / why we need it**:

In order to grant the database permissions correctly, two container app jobs are required. One to grant permissions for the Writer role and then another to grant permissions for the Reader role (using the Writer role). The reason for this is that the Writer role is the owner of the database tables and it is this role that can grant read permissions to other roles to read those tables. 

The changes in this PR are to split the permissions into two separate scripts.

*Link to the relevant work items: e.g: Relates to ADO Work Item [AB#353142](https://dev.azure.com/defragovuk/93c65135-d16b-49d6-a191-4a5313532779/_workitems/edit/353142) and builds on #6702 ([https://dev.azure.com/defragovuk/DEFRA-FFC/_build?definitionId=6702](https://dev.azure.com/defragovuk/DEFRA-FFC/_build?definitionId=6702))*

# **Special notes for your reviewer**
*Any specific actions or notes on review?*

# Testing
*Any relevant testing information and pipeline runs.*

# Checklist (please delete before completing or setting auto-complete)
- [x] Story Work items associated (not Tasks)
- [x] Successful testing run(s) link provided
- [x] Title pattern should be `{work item number}: {title}`
- [x] Description covers all the changes in the PR
- [ ] This PR contains documentation
- [ ] This PR contains tests


# **How does this PR make you feel**:
![gif]([https://giphy.com/)
