### PR TITLE
328599: Update image policy range semver for Ffc Web in SND4

### DIFF
--- a/services/ffc/ffc-demo/ffc-demo-web/infra/snd/04/image-policy.yaml
+++ b/services/ffc/ffc-demo/ffc-demo-web/infra/snd/04/image-policy.yaml
@@ -11,4 +11,4 @@ spec:
     name: ffc-demo-web
   policy:
     semver:
-      range: '>=0.1.0'
+      range: '>=0.1.0-0'


### PR DESCRIPTION
Update image policy range semver for Ffc Demo Web in SND4 so the image policy picks up the image from Container Registry. This is only required while validating SND4 environment

[AB#328599](https://dev.azure.com/defragovuk/93c65135-d16b-49d6-a191-4a5313532779/_workitems/edit/328599)

# **Special notes for your reviewer**
*Any specific actions or notes on review?*

# Testing
*Any relevant testing information and pipeline runs.*

# Checklist (please delete before completing or setting auto-complete)
- [x] Story Work items associated (not Tasks)
- [ ] Successful testing run(s) link provided
- [x] Title pattern should be `{work item number}: {title}`
- [x] Description covers all the changes in the PR
- [ ] This PR contains documentation
- [ ] This PR contains tests


# **How does this PR make you feel**:
![gif]([https://giphy.com/)
