### PR TITLE
383702: Added default memory limit and request to container

### DIFF
--- a/services/base/resource-quota.yaml
+++ b/services/base/resource-quota.yaml
@@ -23,8 +23,10 @@ spec:
   limits:
     - default:
         cpu: 50m
+        memory: 50Mi
       defaultRequest:
         cpu: 50m
+        memory: 50Mi
       max:
         cpu: ${CONTAINER_MAX_CPU:=500m} 
         memory: ${CONTAINER_MAX_MEMORY:=1000Mi}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
If this PR closes an issue, add '<[AB#213700](https://dev.azure.com/defragovuk/93c65135-d16b-49d6-a191-4a5313532779/_workitems/edit/213700)>' somewhere in the PR summary. As a minimum, please *always* link to the relevant work items e.g. [AB#213700](https://dev.azure.com/defragovuk/93c65135-d16b-49d6-a191-4a5313532779/_workitems/edit/213700) (work item number in Azure DevOps). Follow the format below carefully, guidance found here: https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops. Note: The Title pattern should be `{work item number}: {title}` -->

# **What this PR does / why we need it**:
There was a memory issue deploying Elasticsearch helm chart in NCEA-SEARCH namespace. This was due to one of the templates in Elasticsearch has no request and limit defined and it was applying max value defined for that container and this was causing issue scheduling pod on the node.

This change is to add default memory limit and request to container.

Relates to ADO Work Item [AB#383702](https://dev.azure.com/defragovuk/93c65135-d16b-49d6-a191-4a5313532779/_workitems/edit/383702)

# **Special notes for your reviewer**
*Any specific actions or notes on review?*

# Testing
*Any relevant testing information and pipeline runs.*

# Checklist (please delete before completing or setting auto-complete)
- [x] Story Work items associated (not Tasks)
- [ ] Successful testing run(s) link provided
- [x] Title pattern should be `{work item number}: {title}`
- [x] Description covers all the changes in the PR
- [ ] This PR contains documentation
- [ ] This PR contains tests


# **How does this PR make you feel**:
![gif]([https://giphy.com/)
