### PR TITLE
390735: Enable flux notifications for TST, PRE and PRD

### DIFF
--- a/services/environments/prd/base/kustomization.yaml
+++ b/services/environments/prd/base/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - image-update.yaml
+- notification.yaml
 - ../../../ffc/ffc-demo/base/patch
 - ../../../adp-platform/kustomize.yaml
 - ../../../eutd/eutd-find-my-pet/base/patch

--- a/services/environments/pre/base/kustomization.yaml
+++ b/services/environments/pre/base/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - image-update.yaml
+- notification.yaml
 - ../../../ffc/ffc-demo/base/patch
 - ../../../adp-platform/kustomize.yaml
 - ../../../eutd/eutd-find-my-pet/base/patch

--- a/services/environments/tst/base/kustomization.yaml
+++ b/services/environments/tst/base/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - image-update.yaml
+- notification.yaml
 - ../../../ffc/ffc-demo/base/patch
 - ../../../adp-platform/kustomize.yaml
 - ../../../eutd/eutd-find-my-pet/base/patch


### PR DESCRIPTION
# **What this PR does / why we need it**:
Now the Flux Notification Solution has been deployed to Production we can enable the AKS Flux Notifications for TST, PRE and PRD.
[AB#390735](https://dev.azure.com/defragovuk/93c65135-d16b-49d6-a191-4a5313532779/_workitems/edit/390735)

# **Special notes for your reviewer**
*Any specific actions or notes on review?*

# Testing
The Solution has been tested against SND4 cluster in DEFRA sending notifications to the shared PRE eventhub.

https://dev.azure.com/defragovuk/DEFRA-FFC/_build/results?buildId=567425&view=results

Additional testing will be carried out against Production once the ADP-Platform-SSV-PRD-Callback-Api-Client-App app registration has been given consent to the FluxNotifications.Read role

# Checklist (please delete before completing or setting auto-complete)
- [x] Story Work items associated (not Tasks)
- [x] Successful testing run(s) link provided
- [x] Title pattern should be `{work item number}: {title}`
- [x] Description covers all the changes in the PR
- [ ] This PR contains documentation
- [ ] This PR contains tests


# **How does this PR make you feel**:
![gif]([https://giphy.com/)
