### PR TITLE
421970: Remove ffc-demo from PreProd environment in readiness for fcp-demo

### DIFF
--- a/services/environments/pre/base/kustomization.yaml
+++ b/services/environments/pre/base/kustomization.yaml
@@ -3,7 +3,6 @@ kind: Kustomization
 resources:
 - image-update.yaml
 - notification.yaml
-- ../../../ffc/ffc-demo/base/patch
 - ../../../adp-platform/kustomize.yaml
 - ../../../ccts/ccts-adp/base/patch
 - ../../../crai/crai-mcu/base/patch


### PR DESCRIPTION
# **What this PR does / why we need it**:
The ffc-demo app has been moved to fcp-demo.  This is the first step to cleanup the ffc-demo services before migrating fcp-demo in PreProduction

# **Special notes for your reviewer**
*Any specific actions or notes on review?*

# Testing
*Any relevant testing information and pipeline runs.*

# Checklist (please delete before completing or setting auto-complete)
- [x] Story Work items associated (not Tasks)
- [] Successful testing run(s) link provided
- [x] Title pattern should be `{work item number}: {title}`
- [x] Description covers all the changes in the PR
- [ ] This PR contains documentation
- [ ] This PR contains tests


# **How does this PR make you feel**:
![gif]([https://giphy.com/)
