### PR TITLE
Remove fcp-demo services on SND clusters.

### DIFF
--- a/services/fcp/fcp-demo/snd/01/kustomization.yaml
+++ b/services/fcp/fcp-demo/snd/01/kustomization.yaml
@@ -1,5 +1,0 @@
-apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
-resources:
-- ../../base
-- ../../ffc-demo-web

--- a/services/fcp/fcp-demo/snd/02/kustomization.yaml
+++ b/services/fcp/fcp-demo/snd/02/kustomization.yaml
@@ -1,9 +1,0 @@
-apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
-resources:
-- ../../base
-- ../../ffc-demo-web
-- ../../ffc-demo-payment-web
-- ../../ffc-demo-claim-service
-- ../../ffc-demo-payment-service
-- ../../ffc-demo-calculation-service

--- a/services/fcp/fcp-demo/snd/03/kustomization.yaml
+++ b/services/fcp/fcp-demo/snd/03/kustomization.yaml
@@ -1,9 +1,0 @@
-apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
-resources:
-- ../../base
-- ../../ffc-demo-web
-- ../../ffc-demo-payment-web
-- ../../ffc-demo-claim-service
-- ../../ffc-demo-payment-service
-- ../../ffc-demo-calculation-service

--- a/services/fcp/fcp-demo/snd/04/kustomization.yaml
+++ b/services/fcp/fcp-demo/snd/04/kustomization.yaml
@@ -1,9 +1,0 @@
-apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
-resources:
-- ../../base
-- ../../ffc-demo-web
-- ../../ffc-demo-payment-web
-- ../../ffc-demo-claim-service
-- ../../ffc-demo-payment-service
-- ../../ffc-demo-calculation-service


### PR DESCRIPTION
As part of the redis decomissioning work we need to identify services that are using redis. fcp-demo-web is identified as one of those services making use of redis currently. This PR removes the deployment from SND clusters. 

# **What this PR does / why we need it**:
*A brief description of changes being made*
*Link to the relevant work items: e.g: Relates to ADO Work Item [AB#213700](https://dev.azure.com/defragovuk/93c65135-d16b-49d6-a191-4a5313532779/_workitems/edit/213700) and builds on #3376 (link to ADO Build ID URL)*

# **Special notes for your reviewer**
*Any specific actions or notes on review?*

# Testing
*Any relevant testing information and pipeline runs.*

# Checklist (please delete before completing or setting auto-complete)
- [ ] Story Work items associated (not Tasks)
- [ ] Successful testing run(s) link provided
- [ ] Title pattern should be `{work item number}: {title}`
- [ ] Description covers all the changes in the PR
- [ ] This PR contains documentation
- [ ] This PR contains tests


# **How does this PR make you feel**:
![gif]([https://giphy.com/)
